### PR TITLE
Use Java platform to find the home directory

### DIFF
--- a/magik-lint/src/main/java/org/stevenlooman/sw/magik/lint/ConfigurationLocator.java
+++ b/magik-lint/src/main/java/org/stevenlooman/sw/magik/lint/ConfigurationLocator.java
@@ -65,7 +65,7 @@ public class ConfigurationLocator {
     }
 
     // 5. In your home directory
-    String homeEnvVar = System.getenv("HOME");
+    String homeEnvVar = System.getProperty("user.home");
     if (homeEnvVar != null) {
       path = Paths.get(homeEnvVar).resolve(HIDDEN_MAGIK_LINT_RC_FILENAME);
       logger.finest("Trying to get config at (5): " + path.toAbsolutePath());


### PR DESCRIPTION
Small change to use the Java platform to determine the user's home directory. Provides a more robust way on especially Windows platform to determine the home directory. Change should have minimal effect on other platforms.

As a positive side effect this makes the user's home directory configurable by passing the `user.home` property to the VM, eg. ` -Duser.home=/root` .