### PR TITLE
[LineLengthCheck] Treat tabs as spaces for line length

### DIFF
--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
@@ -61,12 +61,13 @@ public class LineLengthCheck extends MagikCheck {
             });
 
             if (columnNo.get() > this.maxLineLength) {
+                final int lineLength = line.replaceAll("\t", " ".repeat(TAB_WIDTH)).length();
                 final URI uri = this.getMagikFile().getUri();
                 final Position startPosition = new Position(lineNo, issueColumnNo.get() - 1);
-                final Position endPosition = new Position(lineNo, line.length());
+                final Position endPosition = new Position(lineNo, lineLength);
                 final Range range = new Range(startPosition, endPosition);
                 final Location location = new Location(uri, range);
-                final String message = String.format(MESSAGE, line.length(), this.maxLineLength);
+                final String message = String.format(MESSAGE, lineLength, this.maxLineLength);
                 this.addIssue(location, message);
             }
 


### PR DESCRIPTION
This fixes the bug that the message showed ea. `Line is too long (115/120)`, but in fact it had to be `Line is too long (122/120)`.
Replace tabs for space * TAB_WIDTH, which will make the line length correctly.

A different approach could be to use `columnNo.get()` as `lineLength`.

