### PR TITLE
[Configuration] Use kebab-case to set parameters for checks

### DIFF
--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
@@ -285,7 +285,7 @@ public class MagikLint {
             final boolean enabled = !disableds.contains(checkKeyKebabCase);
 
             // Gather parameters from MagikCheck, value from config.
-            final String name = checkClass.getAnnotation(Rule.class).key();
+            final String name = MagikCheckHolder.toKebabCase(checkClass.getAnnotation(Rule.class).key());
             final Set<MagikCheckHolder.Parameter> parameters = Arrays.stream(checkClass.getFields())
                 .map(field -> field.getAnnotation(RuleProperty.class))
                 .filter(Objects::nonNull)


### PR DESCRIPTION
Use kebab-case to set parameters for checks. This way the code reflects the [README](https://github.com/StevenLooman/magik-tools/blob/develop/magik-lint/README.md).

If we don't convert it to kebab-case, the properties need to be set like:
`lineLength.line-length=120`

This seems odd, since `disabled=` expects the checks to be in kebab-case. This also creates a uniform configuration file.