### PR TITLE
Make `--show-checks` display a more readable output to distinct enabled/disabled checks

### DIFF
--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
@@ -109,17 +109,20 @@ public class MagikLint {
     /**
      * Show checks active and inactive checks.
      *
+     * @param writer Writer Write to write output to.
+     * @param showDisabled boolean Boolean to show disabled checks or not.
      * @throws ReflectiveOperationException -
      * @throws IOException -
      */
-    void showChecks(final Writer writer) throws ReflectiveOperationException, IOException {
-        final Iterable<MagikCheckHolder> holders = MagikLint.getAllChecks(this.config);
+    void showChecks(final Writer writer, final boolean showDisabled) throws ReflectiveOperationException, IOException {
+        Iterable<MagikCheckHolder> holders = MagikLint.getAllChecks(this.config);
         for (final MagikCheckHolder holder : holders) {
             final String name = holder.getSqKey();
-            if (holder.isEnabled()) {
-                writer.write("Check: " + name + " (" + holder.getTitle() + ")\n");
+
+            if (!showDisabled && holder.isEnabled() || showDisabled && !holder.isEnabled()) {
+                writer.write("- " + name + " (" + holder.getTitle() + ")\n");
             } else {
-                writer.write("Check: " + name + " (disabled) (" + holder.getTitle() + ")\n");
+                continue;
             }
 
             for (final MagikCheckHolder.Parameter parameter : holder.getParameters()) {
@@ -129,6 +132,30 @@ public class MagikLint {
                     + "(" + parameter.getDescription() + ")\n");
             }
         }
+    }
+
+    /**
+     * Show enabled checks.
+     *
+     * @param writer Writer Write to write output to.
+     * @throws ReflectiveOperationException -
+     * @throws IOException -
+     */
+    void showEnabledChecks(final Writer writer) throws ReflectiveOperationException, IOException {
+        writer.write("Enabled checks:\n");
+        this.showChecks(writer, false);
+    }
+
+    /**
+     * Show disabled checks.
+     *
+     * @param writer Writer Write to write output to.
+     * @throws ReflectiveOperationException -
+     * @throws IOException -
+     */
+    void showDisabledChecks(final Writer writer) throws ReflectiveOperationException, IOException {
+        writer.write("Disabled checks:\n");
+        this.showChecks(writer, true);
     }
 
     /**

--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/Main.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/Main.java
@@ -201,7 +201,8 @@ public final class Main {
             final Reporter reporter = new NullReporter();
             final MagikLint lint = new MagikLint(config, reporter);
             final Writer writer = new PrintWriter(System.out);
-            lint.showChecks(writer);
+            lint.showEnabledChecks(writer);
+            lint.showDisabledChecks(writer);
             writer.flush();
             System.exit(0);
         }


### PR DESCRIPTION
It was hard to read in the previous output if a check was enabled disabled. I tried to optimise resulting in the next output:

```
Enabled checks:
- commented-code (Don't leave commented code)
- duplicate-method-in-file (Method is defined multiple times in this file)
- empty-block (Block is empty and can be removed)
- exemplar-slot-count (Exemplars should not have too many slots)
- file-not-in-load-list (File is not included in load_list)
- forbidden-call (Forbidden call)
- forbidden-global-usage (Forbidden usage of global)
- formatting (Improper formatting)
- hides-variable (Variable definition hides another variable with the same name.)
- import-missing-definition (Import missing definition)
- lhs-rhs-comparator-equal (Left hand side and right hand side of comparison are the same)
- line-length (Lines should not be too long)
- local-import-procedure (Possibly meant _import instead of _local)
- method-complexity (Methods should not be too complex)
- method-line-count (Method/procedure is too long)
- no-statement-after-body-exit (No statement after body exit)
- parameter-count (Methods/procedures should not have too many parameters)
- scope-count (Too many variables in scope)
- simplify-if (If statement can be simplified)
- size-zero-empty (Use .empty instead of .size = 0)
- syntax-error (Syntax error)
- trailing-whitespace (Remove the trailing whitespace)
- type-doc (Method is missing documentation)
- undefined-variable (Prefixed variable used as a global)
- unused-variable (Variable is unused)
- use-value-conpare (Compare strings and bignums with the equality-operators)
- variable-count (Method/procedure contains too many variables)
- variable-declaration-usage-distance (Distance between variable definition and usage)
- variable-naming (Give variables a proper descriptive name)
- warned-call (Warned call)
Disabled checks:
- comment-regular-expression (Track comments matching a regular expression)
- file-method-count (Files should not contain too many methods)
- no-self-use (No usage of _self)
- sw-method-doc (Method is missing documentation in Smallworld style)
- xpath (Track breaches of an XPath rule)
```

Instead of:
```
commented-code (Don't leave commented code)
comment-regular-expression (disabled) (Track comments matching a regular expression)
duplicate-method-in-file (Method is defined multiple times in this file)
empty-block (Block is empty and can be removed)
exemplar-slot-count (Exemplars should not have too many slots)
file-method-count (disabled) (Files should not contain too many methods)
file-not-in-load-list (File is not included in load_list)
forbidden-call (Forbidden call)
forbidden-global-usage (Forbidden usage of global)
formatting (Improper formatting)
hides-variable (Variable definition hides another variable with the same name.)
import-missing-definition (Import missing definition)
lhs-rhs-comparator-equal (Left hand side and right hand side of comparison are the same)
line-length (Lines should not be too long)
local-import-procedure (Possibly meant _import instead of _local)
method-complexity (Methods should not be too complex)
method-line-count (Method/procedure is too long)
no-self-use (disabled) (No usage of _self)
no-statement-after-body-exit (No statement after body exit)
parameter-count (Methods/procedures should not have too many parameters)
scope-count (Too many variables in scope)
simplify-if (If statement can be simplified)
size-zero-empty (Use .empty instead of .size = 0)
sw-method-doc (disabled) (Method is missing documentation in Smallworld style)
syntax-error (Syntax error)
trailing-whitespace (Remove the trailing whitespace)
type-doc (Method is missing documentation)
undefined-variable (Prefixed variable used as a global)
unused-variable (Variable is unused)
use-value-conpare (Compare strings and bignums with the equality-operators)
variable-count (Method/procedure contains too many variables)
variable-declaration-usage-distance (Distance between variable definition and usage)
variable-naming (Give variables a proper descriptive name)
warned-call (Warned call)
xpath (disabled) (Track breaches of an XPath rule)
```