### PR TITLE
Fix ForbiddenInheritanceCheck

### DIFF
--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenInheritanceCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenInheritanceCheck.java
@@ -32,7 +32,7 @@ public class ForbiddenInheritanceCheck extends MagikCheck {
      * Forbidden parents to inhertit from, separated by ','.
      */
     @RuleProperty(
-        key = "forbidden parent(s)",
+        key = "forbidden parents",
         defaultValue = "" + DEFAULT_FORBIDDEN_PARENTS,
         description = "Forbidden parents to inhertit from, separated by ','",
         type = "STRING")

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenInheritanceCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenInheritanceCheck.java
@@ -13,13 +13,18 @@ import nl.ramsolutions.sw.magik.analysis.typing.types.TypeString;
 import nl.ramsolutions.sw.magik.checks.DisabledByDefault;
 import nl.ramsolutions.sw.magik.checks.MagikCheck;
 import nl.ramsolutions.sw.magik.parser.TypeStringParser;
+import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 
 /**
  * Check if forbidden inheritance is used.
  */
 @DisabledByDefault
+@Rule(key = ForbiddenInheritanceCheck.CHECK_KEY)
 public class ForbiddenInheritanceCheck extends MagikCheck {
+
+    @SuppressWarnings("checkstyle:JavadocVariable")
+    public static final String CHECK_KEY = "ForbiddenInheritance";
 
     private static final String DEFAULT_FORBIDDEN_PARENTS = "";
 
@@ -27,7 +32,7 @@ public class ForbiddenInheritanceCheck extends MagikCheck {
      * Forbidden parents to inhertit from, separated by ','.
      */
     @RuleProperty(
-        key = "fobidden parents",
+        key = "forbidden parent(s)",
         defaultValue = "" + DEFAULT_FORBIDDEN_PARENTS,
         description = "Forbidden parents to inhertit from, separated by ','",
         type = "STRING")


### PR DESCRIPTION
Running the linter on the latest commit of develop, raised the next error:
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.sonar.check.Rule.key()" because "annotation" is null
	at nl.ramsolutions.sw.magik.lint.MagikLint.getAllChecks(MagikLint.java:317)
	at nl.ramsolutions.sw.magik.lint.MagikLint.showChecks(MagikLint.java:117)
	at nl.ramsolutions.sw.magik.lint.MagikLint.showEnabledChecks(MagikLint.java:143)
	at nl.ramsolutions.sw.magik.lint.Main.main(Main.java:229)
```