### PR TITLE
Fix WarnedCallCheck default warned calls not seeing the sw:-prefixed versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Paths specified in setting `ignore` in `magik-lint.properties` in magik-lint are respected.
 - Fix grammar not supporting end labels in `_loop`/`_endloop` constructs.
 - Fix reading mlint-instructions in scope.
+- Fix WarnedCallCheck default warned calls not seeing the `sw:`-prefixed versions.
 
 0.8.1 (2023-10-15)
 

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheck.java
@@ -19,7 +19,7 @@ public class WarnedCallCheck extends MagikCheck {
     public static final String CHECK_KEY = "WarnedCall";
 
     private static final String MESSAGE = "Call is warned.";
-    private static final String DEFAULT_WARNED_CALLS = "write()";
+    private static final String DEFAULT_WARNED_CALLS = "write(), sw:write()";
 
     /**
      * List of Warned calls, separated by ','.

--- a/magik-checks/src/test/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheckTest.java
+++ b/magik-checks/src/test/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheckTest.java
@@ -33,7 +33,15 @@ class WarnedCallCheckTest extends MagikCheckTestBase {
         final MagikCheck check = new WarnedCallCheck();
         final String code = "write(1)";
         final List<MagikIssue> issues = this.runCheck(code, check);
-        assertThat(issues).isNotEmpty();
+        assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    void testProcedureSwWrite() {
+        final MagikCheck check = new WarnedCallCheck();
+        final String code = "sw:write(1)";
+        final List<MagikIssue> issues = this.runCheck(code, check);
+        assertThat(issues).hasSize(1);
     }
 
 }


### PR DESCRIPTION
Same change as for the [ForbiddenCallCheck](https://github.com/StevenLooman/magik-tools/commit/85da7e8b0fd815d371213b941b8280a31ff0b3fe).