### PR TITLE
Add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
To fix the next warnings (and prevent them in the future):
![image](https://github.com/StevenLooman/magik-tools/assets/12570668/0cfb2204-3f6c-4efa-8999-033a03284e6f)
