### PR TITLE
Make tab width configurable for `LineLengthCheck`

### DIFF
--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/CommentedCodeCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/CommentedCodeCheck.java
@@ -23,7 +23,6 @@ public class CommentedCodeCheck extends MagikCheck {
   public static final String CHECK_KEY = "CommentedCode";
 
   private static final String MESSAGE = "Remove commented code.";
-
   private static final int DEFAULT_MIN_LINES = 3;
 
   /** Minimum number of lines before flagging. */

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
@@ -54,8 +54,8 @@ public class LineLengthCheck extends MagikCheck {
       for (int i = 0; i < line.length(); ++i) {
         final char chr = line.charAt(i);
         if (chr == '\t') {
-          final int mod = columnNo % tabWidth;
-          columnNo += tabWidth - mod;
+          final int mod = columnNo % this.tabWidth;
+          columnNo += this.tabWidth - mod;
         } else {
           ++columnNo;
         }

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/LineLengthCheck.java
@@ -19,7 +19,7 @@ public class LineLengthCheck extends MagikCheck {
 
   private static final String MESSAGE = "Line is too long (%s/%s)";
   private static final int DEFAULT_MAX_LINE_LENGTH = 120;
-  private static final int TAB_WIDTH = 8;
+  private static final int DEFAULT_TAB_WIDTH = 8;
 
   /** Maximum number of characters on a single line. */
   @RuleProperty(
@@ -29,6 +29,15 @@ public class LineLengthCheck extends MagikCheck {
       type = "INTEGER")
   @SuppressWarnings("checkstyle:VisibilityModifier")
   public int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
+
+  /** The width of a tab character. */
+  @RuleProperty(
+      key = "tab width",
+      description = "The width of a tab character",
+      defaultValue = "" + DEFAULT_TAB_WIDTH,
+      type = "INTEGER")
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  public int tabWidth = DEFAULT_TAB_WIDTH;
 
   @Override
   protected void walkPreMagik(final AstNode node) {
@@ -45,8 +54,8 @@ public class LineLengthCheck extends MagikCheck {
       for (int i = 0; i < line.length(); ++i) {
         final char chr = line.charAt(i);
         if (chr == '\t') {
-          final int mod = columnNo % TAB_WIDTH;
-          columnNo += TAB_WIDTH - mod;
+          final int mod = columnNo % tabWidth;
+          columnNo += tabWidth - mod;
         } else {
           ++columnNo;
         }


### PR DESCRIPTION
This is the last property on a check that couldn't be changed (besides the one in #98).

Also changed `CommentedCodeCheck` to have a uniform styling.