### PR TITLE
Align ForbiddenCallCheck and WarnedCallCheck

### DIFF
--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenCallCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/ForbiddenCallCheck.java
@@ -19,7 +19,7 @@ public class ForbiddenCallCheck extends MagikCheck {
 
   private static final String MESSAGE = "Call '%s' is forbidden.";
   private static final String DEFAULT_FORBIDDEN_CALLS =
-      "show(), sw:show(), print(), sw:print(), debug_print(), sw:debug_print(), .sys!perform(), .sys!slot()";
+      "show(),sw:show(),print(),sw:print(),debug_print(),sw:debug_print(),.sys!perform(),.sys!slot()";
 
   /** List of forbidden calls, separated by ','. */
   @RuleProperty(

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/WarnedCallCheck.java
@@ -17,7 +17,7 @@ public class WarnedCallCheck extends MagikCheck {
   @SuppressWarnings("checkstyle:JavadocVariable")
   public static final String CHECK_KEY = "WarnedCall";
 
-  private static final String MESSAGE = "Call is warned.";
+  private static final String MESSAGE = "Call '%s' is warned.";
   private static final String DEFAULT_WARNED_CALLS =
       "write(),sw:write(),remex(),sw:remex(),remove_exemplar(),sw:remove_exemplar()";
 
@@ -59,7 +59,7 @@ public class WarnedCallCheck extends MagikCheck {
       return;
     }
 
-    final AstNode procNode = node.getPreviousSibling();
-    this.addIssue(procNode, MESSAGE);
+    final String message = String.format(MESSAGE, identifier);
+    this.addIssue(parentNode, message);
   }
 }


### PR DESCRIPTION
The only difference between these two checks are the DEFAULT_CALLS, and the severity.
Maybe even introduce a superclass "CallCheck" which both inherit from?