### PR TITLE
Use correct start path for magik-typed-lint

### DIFF
--- a/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/Main.java
+++ b/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/Main.java
@@ -239,7 +239,7 @@ public final class Main {
       }
       properties = new MagikToolsProperties(path);
     } else {
-      final Path currentWorkingPath = Path.of("");
+      final Path currentWorkingPath = Path.of(".");
       final Path path = ConfigurationLocator.locateConfiguration(currentWorkingPath);
       properties =
           path != null ? new MagikToolsProperties(path) : MagikToolsProperties.DEFAULT_PROPERTIES;


### PR DESCRIPTION
Just like was done in https://github.com/StevenLooman/magik-tools/commit/4ea9bdb479e898cee0bb6a69aed57e26ad955540 for magik-lint