### PR TITLE
Improve development experience for LSP and Debug Adapter

### DIFF
--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
@@ -2,13 +2,14 @@ package nl.ramsolutions.sw.magik.debugadapter;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -19,10 +20,19 @@ public final class Main {
   private static final Options OPTIONS;
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
+  private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
+      Option.builder()
+          .longOpt("net")
+          .desc("Open the debug adapter on port 5008 instead of STDIN")
+          .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
+    OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -79,12 +89,35 @@ public final class Main {
     }
 
     final MagikDebugAdapter server = new MagikDebugAdapter();
-    final Launcher<IDebugProtocolClient> launcher =
-        DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<IDebugProtocolClient> launcher;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher = createSocketLauncher(server, new InetSocketAddress("localhost", 5008));
+    } else {
+      launcher = DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    }
 
+    assert launcher != null;
     final IDebugProtocolClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<IDebugProtocolClient> createSocketLauncher(
+      MagikDebugAdapter debugAdapter, SocketAddress socketAddress) throws IOException {
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return DSPLauncher.createServerLauncher(
+            debugAdapter,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel));
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
+    return null;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
@@ -1,0 +1,7 @@
+package nl.ramsolutions.sw.magik.languageserver;
+
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public interface MagikLanguageClient extends LanguageClient {
+  // For future use (custom notifications)
+}

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
@@ -34,7 +34,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
   private final MagikTextDocumentService magikTextDocumentService;
   private final MagikWorkspaceService magikWorkspaceService;
   private final MagikNotebookDocumentService magikNotebookDocumentService;
-  private LanguageClient languageClient;
+  private MagikLanguageClient languageClient;
 
   /**
    * Constructor.
@@ -146,7 +146,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
 
   @Override
   public void connect(final LanguageClient newLanguageClient) {
-    this.languageClient = newLanguageClient;
+    this.languageClient = (MagikLanguageClient) newLanguageClient;
   }
 
   /**
@@ -154,7 +154,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
    *
    * @return Language client.
    */
-  public LanguageClient getLanguageClient() {
+  public MagikLanguageClient getLanguageClient() {
     return this.languageClient;
   }
 

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -2,16 +2,21 @@ package nl.ramsolutions.sw.magik.languageserver;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 /** Main entry point. */
 public final class Main {
@@ -20,15 +25,18 @@ public final class Main {
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
   private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
       Option.builder()
-          .longOpt("stdio")
-          .desc("Use STDIO (default, no other option to interface with this language server)")
+          .longOpt("net")
+          .desc("Open the LSP on port 5007 instead of using STDIN for commands")
           .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
     OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -83,12 +91,54 @@ public final class Main {
     }
 
     final MagikLanguageServer server = new MagikLanguageServer();
-    final Launcher<LanguageClient> launcher =
-        LSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<MagikLanguageClient> launcher;
+    Function<MessageConsumer, MessageConsumer> wrapper = consumer -> (MessageConsumer) consumer;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher =
+          createSocketLauncher(
+              server,
+              new InetSocketAddress("localhost", 5007),
+              Executors.newCachedThreadPool(),
+              wrapper);
+    } else {
+      launcher =
+          Launcher.createIoLauncher(
+              server,
+              MagikLanguageClient.class,
+              System.in,
+              System.out,
+              Executors.newCachedThreadPool(),
+              wrapper);
+    }
 
+    assert launcher != null;
     final LanguageClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<MagikLanguageClient> createSocketLauncher(
+      LanguageServer languageServer,
+      SocketAddress socketAddress,
+      ExecutorService executorService,
+      Function<MessageConsumer, MessageConsumer> wrapper)
+      throws IOException {
+    AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress);
+    AsynchronousSocketChannel socketChannel;
+    try {
+      socketChannel = serverSocket.accept().get();
+      return Launcher.createIoLauncher(
+          languageServer,
+          MagikLanguageClient.class,
+          Channels.newInputStream(socketChannel),
+          Channels.newOutputStream(socketChannel),
+          executorService,
+          wrapper);
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+    return null;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -124,20 +124,21 @@ public final class Main {
       ExecutorService executorService,
       Function<MessageConsumer, MessageConsumer> wrapper)
       throws IOException {
-    AsynchronousServerSocketChannel serverSocket =
-        AsynchronousServerSocketChannel.open().bind(socketAddress);
-    AsynchronousSocketChannel socketChannel;
-    try {
-      socketChannel = serverSocket.accept().get();
-      return Launcher.createIoLauncher(
-          languageServer,
-          MagikLanguageClient.class,
-          Channels.newInputStream(socketChannel),
-          Channels.newOutputStream(socketChannel),
-          executorService,
-          wrapper);
-    } catch (InterruptedException | ExecutionException e) {
-      e.printStackTrace();
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return Launcher.createIoLauncher(
+            languageServer,
+            MagikLanguageClient.class,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel),
+            executorService,
+            wrapper);
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
     }
     return null;
   }


### PR DESCRIPTION
Hi Steven,

this pull requests add options to the LSP and Debug Adapter so that they can run on a socket (port 5007 and 5008 respectively). This makes it possible to start the LSP/Debug Adapter in your IDE of choice and interactively debug it there.

## LSP

In order to use a LSP running on a socket in VS Code, you can use the following `serverOptions` when creating a new `LanguageClient`

```typescript
serverOptions = (): Promise<vscodeLanguageClient.StreamInfo> => `{laun`
  const socket = net.connect({ port: 5007 });
  return Promise.resolve({
    writer: socket,
    reader: socket,
  });
};
```

## Debug Adapter (launch.json)

Using the Debug Adapter through a socket is done by specifying `debugServer` in a launch configuration.

```json
{
  "type": "magik",
  "name": "Socket debugging",
  "request": "attach",
  "debugServer": 5008,
  "connect": {
    "host": "localhost",
    "port": 32000,
    "path_mapping": []
  }
}
```