### PR TITLE
Rewrite Reading and Writing of definitions for faster parsing

### DIFF
--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
@@ -2,13 +2,14 @@ package nl.ramsolutions.sw.magik.debugadapter;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -19,10 +20,19 @@ public final class Main {
   private static final Options OPTIONS;
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
+  private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
+      Option.builder()
+          .longOpt("net")
+          .desc("Open the debug adapter on port 5008 instead of STDIN")
+          .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
+    OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -79,12 +89,35 @@ public final class Main {
     }
 
     final MagikDebugAdapter server = new MagikDebugAdapter();
-    final Launcher<IDebugProtocolClient> launcher =
-        DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<IDebugProtocolClient> launcher;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher = createSocketLauncher(server, new InetSocketAddress("localhost", 5008));
+    } else {
+      launcher = DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    }
 
+    assert launcher != null;
     final IDebugProtocolClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<IDebugProtocolClient> createSocketLauncher(
+      MagikDebugAdapter debugAdapter, SocketAddress socketAddress) throws IOException {
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return DSPLauncher.createServerLauncher(
+            debugAdapter,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel));
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
+    return null;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/JsonObjectPropertiesConverter.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/JsonObjectPropertiesConverter.java
@@ -29,15 +29,26 @@ final class JsonObjectPropertiesConverter {
       final boolean containsNonPrimitives =
           StreamSupport.stream(jsonArray.spliterator(), false)
               .anyMatch(childJsonEl -> !childJsonEl.isJsonPrimitive());
-      if (containsNonPrimitives) {
-        throw new IllegalStateException("Cannot convert JsonArray with non-JsonPrimitives!");
-      }
+      final JsonArray primitiveJsonArray = new JsonArray();
+      StreamSupport.stream(jsonArray.spliterator(), false)
+          .forEach(
+              childJsonEl -> {
+                if (childJsonEl.isJsonPrimitive()) {
+                  primitiveJsonArray.add(childJsonEl);
+                } else {
+                  primitiveJsonArray.add(childJsonEl.toString());
+                }
+              });
 
       // Convert all values.
       final String value =
-          StreamSupport.stream(jsonArray.spliterator(), false)
+          StreamSupport.stream(primitiveJsonArray.spliterator(), false)
               .map(JsonElement::getAsString)
-              .collect(Collectors.joining(MagikToolsProperties.LIST_SEPARATOR));
+              .collect(
+                  Collectors.joining(
+                      containsNonPrimitives
+                          ? MagikToolsProperties.LIST_SEPARATOR_OBJ
+                          : MagikToolsProperties.LIST_SEPARATOR));
       properties.put(path, value);
     } else if (jsonElement.isJsonObject()) {
       final JsonObject jsonObject = (JsonObject) jsonElement;

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
@@ -1,0 +1,7 @@
+package nl.ramsolutions.sw.magik.languageserver;
+
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public interface MagikLanguageClient extends LanguageClient {
+  // For future use (custom notifications)
+}

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
@@ -34,7 +34,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
   private final MagikTextDocumentService magikTextDocumentService;
   private final MagikWorkspaceService magikWorkspaceService;
   private final MagikNotebookDocumentService magikNotebookDocumentService;
-  private LanguageClient languageClient;
+  private MagikLanguageClient languageClient;
 
   /**
    * Constructor.
@@ -146,7 +146,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
 
   @Override
   public void connect(final LanguageClient newLanguageClient) {
-    this.languageClient = newLanguageClient;
+    this.languageClient = (MagikLanguageClient) newLanguageClient;
   }
 
   /**
@@ -154,7 +154,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
    *
    * @return Language client.
    */
-  public LanguageClient getLanguageClient() {
+  public MagikLanguageClient getLanguageClient() {
     return this.languageClient;
   }
 

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServerSettings.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServerSettings.java
@@ -2,8 +2,11 @@ package nl.ramsolutions.sw.magik.languageserver;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import nl.ramsolutions.sw.MagikToolsProperties;
+import nl.ramsolutions.sw.magik.PathMapping;
 
 /** Magik settings. */
 public final class MagikLanguageServerSettings {
@@ -14,6 +17,11 @@ public final class MagikLanguageServerSettings {
   private static final String SHOW_TYPING_INLAY_HINTS = "magik.typing.showTypingInlayHints";
   private static final String SHOW_ARGUMENT_INLAY_HINTS = "magik.typing.showArgumentInlayHints";
   private static final String ENABLE_TYPING_CHECKS = "magik.typing.enableChecks";
+  public static final String SMALLWORLD_GIS = "magik.smallworldGis";
+  public static final String PATH_MAPPING = "magik.pathMapping";
+
+  private static List<PathMapping> pathMappings = new CopyOnWriteArrayList<>();
+  private static String pathMappingsStr = "";
 
   private final MagikToolsProperties properties;
 
@@ -77,5 +85,35 @@ public final class MagikLanguageServerSettings {
   public Path getChecksOverrideSettingsPath() {
     final String overrideConfigFile = this.properties.getPropertyString(OVERRIDE_CONFIG_FILE);
     return overrideConfigFile != null ? Path.of(overrideConfigFile) : null;
+  }
+
+  @CheckForNull
+  public String getSmallworldGis() {
+    return this.properties.getPropertyString(SMALLWORLD_GIS);
+  }
+
+  /**
+   * Get magik.pathMapping, defaults to an empty list if not defined
+   *
+   * @return the path mappings
+   */
+  public List<PathMapping> getPathMappings() {
+    // get cached path mappings for performance
+    String unparsedMappingsStr = this.properties.getPropertyString(PATH_MAPPING);
+    if (unparsedMappingsStr == null) {
+      return Collections.emptyList();
+    }
+    if (unparsedMappingsStr.equals(MagikLanguageServerSettings.pathMappingsStr)) {
+      return MagikLanguageServerSettings.pathMappings;
+    }
+
+    List<PathMapping> mappings =
+        new CopyOnWriteArrayList<>(
+            this.properties.getPropertyList(PATH_MAPPING, null, PathMapping.class));
+
+    MagikLanguageServerSettings.pathMappings = mappings;
+    MagikLanguageServerSettings.pathMappingsStr = unparsedMappingsStr;
+
+    return mappings;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikWorkspaceService.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikWorkspaceService.java
@@ -1,15 +1,14 @@
 package nl.ramsolutions.sw.magik.languageserver;
 
 import com.google.gson.JsonObject;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import nl.ramsolutions.sw.IgnoreHandler;
 import nl.ramsolutions.sw.MagikToolsProperties;
 import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
@@ -128,20 +127,47 @@ public class MagikWorkspaceService implements WorkspaceService {
   public void readTypesDbs(final List<String> typeDbPaths) {
     LOGGER.trace("Reading type databases from: {}", typeDbPaths);
 
-    typeDbPaths.forEach(
-        pathStr -> {
-          final Path path = Path.of(pathStr);
-          if (!Files.exists(path)) {
-            LOGGER.warn("Path to types database does not exist: {}", pathStr);
-            return;
-          }
+    final MagikLanguageServerSettings lspSettings =
+        new MagikLanguageServerSettings(this.languageServerProperties);
+    final String smallworldGis = lspSettings.getSmallworldGis();
 
-          try {
-            JsonDefinitionReader.readTypes(path, this.definitionKeeper);
-          } catch (final IOException exception) {
-            LOGGER.error(exception.getMessage(), exception);
-          }
-        });
+    typeDbPaths.stream()
+        .map(
+            pathStr -> {
+              Path path = JsonDefinitionReader.parseTypeDBPath(smallworldGis, pathStr);
+              if (path == null) {
+                LOGGER.warn("Path to types database does not exist: {}", pathStr);
+                return null;
+              }
+              return path;
+            })
+        .filter(Objects::nonNull)
+        .flatMap(
+            path -> {
+              if (Files.isDirectory(path)) {
+                File dir = path.toFile();
+                File[] files =
+                    dir.listFiles((dir1, name) -> name.endsWith(JsonDefinitionReader.TYPE_DB_EXT));
+                if (files != null) {
+                  return Arrays.stream(files).map(File::toPath);
+                }
+                return Stream.empty();
+              }
+              return Stream.of(path);
+            })
+        .forEach(
+            path -> {
+              try {
+                JsonDefinitionReader.readTypes(
+                    path, this.definitionKeeper, lspSettings.getPathMappings());
+              } catch (final Exception exception) {
+                LOGGER.error(
+                    "error reading type db '{}', error: {}",
+                    path,
+                    exception.getMessage(),
+                    exception);
+              }
+            });
   }
 
   @Override

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -2,16 +2,21 @@ package nl.ramsolutions.sw.magik.languageserver;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 /** Main entry point. */
 public final class Main {
@@ -20,15 +25,18 @@ public final class Main {
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
   private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
       Option.builder()
-          .longOpt("stdio")
-          .desc("Use STDIO (default, no other option to interface with this language server)")
+          .longOpt("net")
+          .desc("Open the LSP on port 5007 instead of using STDIN for commands")
           .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
     OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -83,12 +91,54 @@ public final class Main {
     }
 
     final MagikLanguageServer server = new MagikLanguageServer();
-    final Launcher<LanguageClient> launcher =
-        LSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<MagikLanguageClient> launcher;
+    Function<MessageConsumer, MessageConsumer> wrapper = consumer -> (MessageConsumer) consumer;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher =
+          createSocketLauncher(
+              server,
+              new InetSocketAddress("localhost", 5007),
+              Executors.newCachedThreadPool(),
+              wrapper);
+    } else {
+      launcher =
+          Launcher.createIoLauncher(
+              server,
+              MagikLanguageClient.class,
+              System.in,
+              System.out,
+              Executors.newCachedThreadPool(),
+              wrapper);
+    }
 
+    assert launcher != null;
     final LanguageClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<MagikLanguageClient> createSocketLauncher(
+      LanguageServer languageServer,
+      SocketAddress socketAddress,
+      ExecutorService executorService,
+      Function<MessageConsumer, MessageConsumer> wrapper)
+      throws IOException {
+    AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress);
+    AsynchronousSocketChannel socketChannel;
+    try {
+      socketChannel = serverSocket.accept().get();
+      return Launcher.createIoLauncher(
+          languageServer,
+          MagikLanguageClient.class,
+          Channels.newInputStream(socketChannel),
+          Channels.newOutputStream(socketChannel),
+          executorService,
+          wrapper);
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+    return null;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -124,20 +124,21 @@ public final class Main {
       ExecutorService executorService,
       Function<MessageConsumer, MessageConsumer> wrapper)
       throws IOException {
-    AsynchronousServerSocketChannel serverSocket =
-        AsynchronousServerSocketChannel.open().bind(socketAddress);
-    AsynchronousSocketChannel socketChannel;
-    try {
-      socketChannel = serverSocket.accept().get();
-      return Launcher.createIoLauncher(
-          languageServer,
-          MagikLanguageClient.class,
-          Channels.newInputStream(socketChannel),
-          Channels.newOutputStream(socketChannel),
-          executorService,
-          wrapper);
-    } catch (InterruptedException | ExecutionException e) {
-      e.printStackTrace();
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return Launcher.createIoLauncher(
+            languageServer,
+            MagikLanguageClient.class,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel),
+            executorService,
+            wrapper);
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
     }
     return null;
   }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/MagikToolsProperties.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/MagikToolsProperties.java
@@ -1,15 +1,14 @@
 package nl.ramsolutions.sw;
 
+import com.google.gson.*;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
+import java.util.stream.Stream;
+import nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer.PathDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +17,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Note that this is currently used in (at least) three ways: - Settings for
  * magik-language-server settings - Settings for magik-lint from command line - Settings for
- * `magik-lint.properties` files for a given {@link MagikFile}
+ * `magik-lint.properties` files for a given {@link nl.ramsolutions.sw.magik.MagikFile}
  *
  * <p>These are separate code-paths, but given the shared used of {@link MagikToolsProperties} the
  * separation can be confusing.
@@ -30,6 +29,12 @@ public class MagikToolsProperties {
 
   public static final MagikToolsProperties DEFAULT_PROPERTIES = new MagikToolsProperties(Map.of());
   public static final String LIST_SEPARATOR = ",";
+
+  /**
+   * this is used for when an array of objects is separated into a property list `\u001b`
+   * corresponds to the ESCAPE key
+   */
+  public static final String LIST_SEPARATOR_OBJ = "\u001b";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MagikToolsProperties.class);
 
@@ -274,7 +279,7 @@ public class MagikToolsProperties {
 
   /**
    * Get a property value as a {@link List}. Items are separated by {@link
-   * MagikToolsProperties.LIST_SEPARATOR}.
+   * MagikToolsProperties#LIST_SEPARATOR}.
    *
    * @param key Key of the property.
    * @return List of values.
@@ -287,6 +292,78 @@ public class MagikToolsProperties {
 
     final String[] values = value.split(MagikToolsProperties.LIST_SEPARATOR);
     return Arrays.stream(values).map(String::trim).toList();
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> List<T> getPropertyList(
+      final String key, @Nullable String separator, final Class<T> type) {
+    final String value = this.getPropertyString(key);
+    if (value == null || value.isBlank()) {
+      return Collections.emptyList();
+    }
+
+    if (separator == null) {
+      if (type.isPrimitive()) {
+        separator = LIST_SEPARATOR;
+      } else {
+        separator = LIST_SEPARATOR_OBJ;
+      }
+    }
+
+    Stream<String> valuesStream = Arrays.stream(value.split(separator)).map(String::trim);
+
+    List<?> values;
+    String typeName = type.getSimpleName();
+    switch (typeName) {
+      case "Integer":
+        values = valuesStream.map(Integer::valueOf).toList();
+        break;
+      case "Long":
+        values = valuesStream.map(Long::valueOf).toList();
+        break;
+      case "Double":
+        values = valuesStream.map(Double::valueOf).toList();
+        break;
+      case "Float":
+        values = valuesStream.map(Float::valueOf).toList();
+        break;
+      case "Boolean":
+        values = valuesStream.map(Boolean::valueOf).toList();
+        break;
+      case "Byte":
+        values = valuesStream.map(Byte::valueOf).toList();
+        break;
+      case "Short":
+        values = valuesStream.map(Short::valueOf).toList();
+        break;
+      case "Character":
+        values = valuesStream.filter(str -> !str.isBlank()).map(str -> str.charAt(0)).toList();
+        break;
+      case "String":
+        values = valuesStream.toList();
+        break;
+      default:
+        Gson gson =
+            new GsonBuilder()
+                .registerTypeAdapter(Path.class, new PathDeserializer(Collections.emptyList()))
+                .create();
+        values =
+            valuesStream
+                .map(
+                    v -> {
+                      try {
+                        final JsonElement el = JsonParser.parseString(v);
+                        return gson.fromJson(el, type);
+                      } catch (JsonSyntaxException e) {
+                        LOGGER.error("Could not read value {} with type {}", v, type, e);
+                        return null;
+                      }
+                    })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    return (List<T>) values;
   }
 
   /**

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/Location.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/Location.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 /** Location within a file. */
@@ -153,8 +154,26 @@ public class Location {
    * @return Location.
    */
   public static Location validLocation(final @Nullable Location location) {
+    return validLocation(location, null);
+  }
+
+  /**
+   * Ensure a complete location, with a range.
+   *
+   * @param location Range to derive from.
+   * @param mappings the path mappings to use
+   * @return Location.
+   */
+  public static Location validLocation(
+      @Nullable Location location, final @Nullable List<PathMapping> mappings) {
     if (location == null) {
       return MagikFile.DEFAULT_LOCATION;
+    }
+
+    if (mappings != null) {
+      for (PathMapping mapping : mappings) {
+        location = mapping.mapLocation(location);
+      }
     }
 
     final Range range = location.getRange();

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/PathMapping.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/PathMapping.java
@@ -1,0 +1,82 @@
+package nl.ramsolutions.sw.magik;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PathMapping {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PathMapping.class);
+
+  private final Path from;
+  private final Path to;
+  private Boolean writable = false;
+
+  public PathMapping() {
+    from = null;
+    to = null;
+  }
+
+  public PathMapping(String from, String to) {
+    this.from = Path.of(from);
+    this.to = Path.of(to);
+  }
+
+  public PathMapping(String from, String to, Boolean writable) {
+    this(from, to);
+    this.writable = writable;
+  }
+
+  public Path getFrom() {
+    return from;
+  }
+
+  public Path getTo() {
+    return to;
+  }
+
+  @SuppressWarnings("unused")
+  public Boolean getWritable() {
+    return writable;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PathMapping that = (PathMapping) o;
+    return Objects.equals(getFrom(), that.getFrom()) && Objects.equals(getTo(), that.getTo());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getFrom(), getTo());
+  }
+
+  public boolean isInvalidPathMapping() {
+    return from == null || to == null;
+  }
+
+  public Location mapLocation(Location location) {
+    String path = location.getPath().toString();
+    if (this.isInvalidPathMapping()) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Could not use invalid path mapping from: {}, to: {}", from, to);
+      }
+
+      return location;
+    }
+
+    if (path.startsWith(this.from.toString())) {
+      Path newPath = Path.of(path.replace(this.from.toString(), this.to.toString()));
+      if (newPath.toFile().exists()) {
+        location =
+            new Location(
+                Path.of(path.replace(this.from.toString(), this.to.toString())).toUri(),
+                location.getRange());
+      }
+    }
+
+    return location;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/Instruction.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/Instruction.java
@@ -2,26 +2,27 @@ package nl.ramsolutions.sw.magik.analysis.definitions.io;
 
 /** Json TypeKeeper Reader/Writer instructions. */
 @SuppressWarnings("checkstyle:JavadocVariable")
-enum Instruction {
-  INSTRUCTION("instruction"),
-  PRODUCT("product"),
-  MODULE("module"),
-  MAGIK_FILE("magik_file"),
-  PACKAGE("package"),
-  TYPE("type"),
-  GLOBAL("global"),
-  METHOD("method"),
-  PROCEDURE("procedure"),
-  CONDITION("condition"),
-  BINARY_OPERATOR("binary_operator");
+public enum Instruction {
+  PRODUCT(1),
+  MODULE(2),
+  PACKAGE(3),
+  TYPE(4),
+  GLOBAL(5),
+  METHOD(6),
+  PROCEDURE(7),
+  CONDITION(8),
+  BINARY_OPERATOR(9),
+  MAGIK_FILE(10);
 
-  private final String value;
+  public static final String FIELD_NAME = "i";
 
-  Instruction(final String value) {
+  private final Integer value;
+
+  Instruction(final Integer value) {
     this.value = value;
   }
 
-  public String getValue() {
+  public Integer getValue() {
     return this.value;
   }
 
@@ -31,7 +32,7 @@ enum Instruction {
    * @param value Value to get enum from.
    * @return Enum.
    */
-  public static Instruction fromValue(final String value) {
+  public static Instruction fromValue(final Integer value) {
     for (final Instruction instruction : Instruction.values()) {
       if (instruction.getValue().equals(value)) {
         return instruction;

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionReader.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionReader.java
@@ -1,222 +1,170 @@
 package nl.ramsolutions.sw.magik.analysis.definitions.io;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.InstanceCreator;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
-import java.util.Arrays;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import nl.ramsolutions.sw.magik.analysis.definitions.BinaryOperatorDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ConditionDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.GlobalDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
-import nl.ramsolutions.sw.magik.analysis.definitions.MagikFileDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.MethodDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.PackageDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ParameterDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ProcedureDefinition;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.*;
+import nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer.*;
 import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
 import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
-import nl.ramsolutions.sw.magik.parser.TypeStringParser;
 import nl.ramsolutions.sw.moduledef.ModuleDefinition;
+import nl.ramsolutions.sw.moduledef.ModuleUsage;
 import nl.ramsolutions.sw.productdef.ProductDefinition;
+import nl.ramsolutions.sw.productdef.ProductUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** JSON-line TypeKeeper reader. */
 public final class JsonDefinitionReader {
 
-  private static final class TypeStringDeserializer implements JsonDeserializer<TypeString> {
-
-    @Override
-    public TypeString deserialize(
-        final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
-        throws JsonParseException {
-      final String identifier = json.getAsString();
-      return TypeStringParser.parseTypeString(identifier);
-    }
-  }
-
-  private static final class ExpressionResultStringDeserializer
-      implements JsonDeserializer<ExpressionResultString> {
-
-    @Override
-    public ExpressionResultString deserialize(
-        final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
-        throws JsonParseException {
-      if (json.isJsonPrimitive()
-          && json.getAsString().equals(ExpressionResultString.UNDEFINED_SERIALIZED_NAME)) {
-        return ExpressionResultString.UNDEFINED;
-      } else if (json.isJsonArray()) {
-        final List<TypeString> types =
-            json.getAsJsonArray().asList().stream()
-                .map(JsonElement::getAsString)
-                .map(TypeStringParser::parseTypeString)
-                .toList();
-        return new ExpressionResultString(types);
-      }
-
-      throw new IllegalStateException();
-    }
-  }
-
-  private static final class LowerCaseEnumDeserializer<E extends Enum<?>>
-      implements JsonDeserializer<E> {
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public E deserialize(
-        final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
-        throws JsonParseException {
-      final String value = json.getAsString().toUpperCase();
-      if (typeOfT instanceof Class) {
-        final Class<?> clazz = (Class<?>) typeOfT;
-        if (clazz.isEnum()) {
-          return Arrays.stream(clazz.getEnumConstants())
-              .filter(enumValue -> enumValue.toString().equals(value))
-              .map(enumValue -> (E) enumValue)
-              .findFirst()
-              .orElseThrow();
-        }
-      }
-
-      throw new IllegalStateException("Value '" + value + "' is not a known Enum value");
-    }
-  }
-
-  private static final class InstantDeserializer implements JsonDeserializer<Instant> {
-
-    @Override
-    public Instant deserialize(
-        final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
-        throws JsonParseException {
-      final JsonArray array = json.getAsJsonArray();
-      if (array.size() == 2) {
-        final long seconds = array.get(0).getAsLong();
-        final long nanos = array.get(1).getAsLong();
-        return Instant.ofEpochSecond(seconds, nanos);
-      }
-
-      throw new IllegalStateException();
-    }
-  }
-
-  private static final class ProductDefinitionCreator
-      implements InstanceCreator<ProductDefinition> {
-
-    @Override
-    public ProductDefinition createInstance(final Type type) {
-      // This ensures `MethodDefinition.usedGlobals` etc are initialized properly,
-      // even if these were not set in the source JSON.
-      return new ProductDefinition(
-          null, null, null, null, null, null, null, null, Collections.emptyList());
-    }
-  }
-
-  private static final class ModuleDefinitionCreator implements InstanceCreator<ModuleDefinition> {
-
-    @Override
-    public ModuleDefinition createInstance(final Type type) {
-      // This ensures `MethodDefinition.usedGlobals` etc are initialized properly,
-      // even if these were not set in the source JSON.
-      return new ModuleDefinition(
-          null, null, null, null, null, null, null, Collections.emptyList());
-    }
-  }
-
-  private static final class MethodDefinitionCreator implements InstanceCreator<MethodDefinition> {
-
-    @Override
-    public MethodDefinition createInstance(final Type type) {
-      // This ensures `MethodDefinition.usedGlobals` etc are initialized properly,
-      // even if these were not set in the source JSON.
-      return new MethodDefinition(
-          null,
-          null,
-          null,
-          null,
-          null,
-          TypeString.UNDEFINED,
-          "dummy_method",
-          Collections.emptySet(),
-          Collections.emptyList(),
-          null,
-          Collections.emptySet(),
-          ExpressionResultString.UNDEFINED,
-          ExpressionResultString.UNDEFINED);
-    }
-  }
-
-  private static final class ExemplarDefinitionCreator
-      implements InstanceCreator<ExemplarDefinition> {
-
-    @Override
-    public ExemplarDefinition createInstance(final Type type) {
-      // This ensures `MethodDefinition.usedGlobals` etc are initialized properly,
-      // even if these were not set in the source JSON.
-      return new ExemplarDefinition(
-          null,
-          null,
-          null,
-          null,
-          null,
-          ExemplarDefinition.Sort.UNDEFINED,
-          TypeString.UNDEFINED,
-          Collections.emptyList(),
-          Collections.emptyList(),
-          Collections.emptySet());
-    }
-  }
-
-  private static final class ProcedureDefinitionCreator
-      implements InstanceCreator<ProcedureDefinition> {
-
-    @Override
-    public ProcedureDefinition createInstance(final Type type) {
-      // This ensures `MethodDefinition.usedGlobals` etc are initialized properly,
-      // even if these were not set in the source JSON.
-      return new ProcedureDefinition(
-          null,
-          null,
-          null,
-          null,
-          null,
-          Collections.emptySet(),
-          TypeString.UNDEFINED,
-          null,
-          Collections.emptyList(),
-          ExpressionResultString.UNDEFINED,
-          ExpressionResultString.UNDEFINED);
-    }
-  }
-
   private static final Logger LOGGER = LoggerFactory.getLogger(JsonDefinitionReader.class);
+  private static final Logger LOGGER_DURATION =
+      LoggerFactory.getLogger(JsonDefinitionReader.class.getName() + "Duration");
+
+  public static final String TYPE_DB_DEFAULT_ALIAS = "$default";
+  private static final String TYPE_DB_DEFAULT_PATH =
+      "../../type_dbs"; // relative to smallworldGis path
+  public static final Integer TYPE_DB_VERSION = 2;
+  public static final String TYPE_DB_EXT = ".v" + TYPE_DB_VERSION + ".jsonl";
 
   private final IDefinitionKeeper definitionKeeper;
+  private final List<PathMapping> mappings;
+  private final Gson gson;
+  private final ExecutorService threadPool;
 
-  private JsonDefinitionReader(final IDefinitionKeeper definitionKeeper) {
+  private JsonDefinitionReader(
+      final IDefinitionKeeper definitionKeeper, final @Nullable List<PathMapping> mappings) {
     this.definitionKeeper = definitionKeeper;
+    this.mappings = mappings;
+
+    final int processors = Runtime.getRuntime().availableProcessors();
+    final int threadsToRun = Math.max(processors / 2, 6);
+    this.threadPool = Executors.newFixedThreadPool(threadsToRun);
+
+    this.gson = this.createGson();
   }
 
-  private void run(final Path path) throws IOException {
-    LOGGER.debug("Reading type database from path: {}", path);
+  private Gson createGson() {
+    final GsonBuilder builder = new GsonBuilder();
+    return builder
+        .registerTypeAdapter(TypeString.class, new TypeStringDeserializer(mappings))
+        .registerTypeAdapter(
+            ExpressionResultString.class, new ExpressionResultStringDeserializer(mappings))
+        .registerTypeAdapter(
+            ExemplarDefinition.Sort.class,
+            new LowerCaseEnumDeserializer<>(mappings, ExemplarDefinition.Sort.class))
+        .registerTypeAdapter(
+            MethodDefinition.Modifier.class,
+            new LowerCaseEnumDeserializer<>(mappings, MethodDefinition.Modifier.class))
+        .registerTypeAdapter(
+            ProcedureDefinition.Modifier.class,
+            new LowerCaseEnumDeserializer<>(mappings, ProcedureDefinition.Modifier.class))
+        .registerTypeAdapter(
+            ParameterDefinition.Modifier.class,
+            new LowerCaseEnumDeserializer<>(mappings, ParameterDefinition.Modifier.class))
+        .registerTypeAdapter(SlotDefinition.class, new SlotDefinitionDeserializer(mappings))
+        .registerTypeAdapter(
+            ParameterDefinition.class, new ParameterDefinitionDeserializer(mappings))
+        .registerTypeAdapter(ProductDefinition.class, new ProductDefinitionDeserializer(mappings))
+        .registerTypeAdapter(ModuleDefinition.class, new ModuleDefinitionDeserializer(mappings))
+        .registerTypeAdapter(PackageDefinition.class, new PackageDefinitionDeserializer(mappings))
+        .registerTypeAdapter(ExemplarDefinition.class, new ExemplarDefinitionDeserializer(mappings))
+        .registerTypeAdapter(MethodDefinition.class, new MethodDefinitionDeserializer(mappings))
+        .registerTypeAdapter(
+            ConditionDefinition.class, new ConditionDefinitionDeserializer(mappings))
+        .registerTypeAdapter(
+            BinaryOperatorDefinition.class, new BinaryOperatorDefinitionDeserializer(mappings))
+        .registerTypeAdapter(
+            ProcedureDefinition.class, new ProcedureDefinitionDeserializer(mappings))
+        .registerTypeAdapter(GlobalDefinition.class, new GlobalDefinitionDeserializer(mappings))
+        .registerTypeAdapter(ProductUsage.class, new ProductUsageDeserializer(mappings))
+        .registerTypeAdapter(ModuleUsage.class, new ModuleUsageDeserializer(mappings))
+        .registerTypeAdapter(
+            MagikFileDefinition.class, new MagikFileDefinitionDeserializer(mappings))
+        .create();
+  }
+
+  /**
+   * Read types from a JSON-line file.
+   *
+   * @param path Path to JSON-line file.
+   * @param definitionKeeper {@link IDefinitionKeeper} to fill.
+   */
+  public static void readTypes(final Path path, final IDefinitionKeeper definitionKeeper) {
+    readTypes(path, definitionKeeper, Collections.emptyList());
+  }
+
+  /**
+   * Read types from a JSON-line file.
+   *
+   * @param path Path to JSON-line file.
+   * @param definitionKeeper {@link IDefinitionKeeper} to fill.
+   * @param mappings the path mappings to use for locations
+   */
+  public static void readTypes(
+      final Path path,
+      final IDefinitionKeeper definitionKeeper,
+      final @Nullable List<PathMapping> mappings) {
+    BaseDeserializer.clearParsedFiles();
+
+    final JsonDefinitionReader reader = new JsonDefinitionReader(definitionKeeper, mappings);
+    final long start = System.nanoTime();
+    reader.run(path);
+    LOGGER_DURATION.trace(
+        "Duration: {} readTypes, type db: {}", (System.nanoTime() - start) / 1000000000.0, path);
+  }
+
+  /**
+   * parses a path for a type db and will replace {@value
+   * JsonDefinitionReader#TYPE_DB_DEFAULT_ALIAS} with the default type db path
+   *
+   * @param gisPath the gisPath if the default alias gets replaced
+   * @param pathStr the path that should get parsed
+   * @return the parsed Path or null if the file can't be found
+   */
+  @Nullable
+  public static Path parseTypeDBPath(@Nullable String gisPath, String pathStr) {
+    Path path = Path.of(pathStr);
+    if (pathStr.equals(TYPE_DB_DEFAULT_ALIAS) && gisPath != null) {
+      path = generateDefaultTypeDBPath(gisPath);
+    }
+
+    if (!Files.exists(path)) {
+      return null;
+    }
+
+    return path;
+  }
+
+  /**
+   * Generate the default type db path
+   *
+   * @param gisPath the Smallworld GIS path to use as the basis
+   * @return the path
+   */
+  public static Path generateDefaultTypeDBPath(String gisPath) {
+    return Paths.get(gisPath, TYPE_DB_DEFAULT_PATH);
+  }
+
+  public void run(final Path path) {
+    LOGGER.info("Reading type database from path: {}", path);
+
+    List<CompletableFuture<Boolean>> completableFutures = new ArrayList<>();
 
     final File file = path.toFile();
     int lineNo = 1;
@@ -224,36 +172,60 @@ public final class JsonDefinitionReader {
         BufferedReader bufferedReader = new BufferedReader(fileReader)) {
       String line = bufferedReader.readLine();
       while (line != null) {
-        this.processLineSafe(lineNo, line);
+        completableFutures.add(this.processLineSafe(lineNo, line, path));
 
         ++lineNo;
         line = bufferedReader.readLine();
       }
-    } catch (final JsonParseException exception) {
-      LOGGER.error("JSON Error reading line no: {}", lineNo);
+    } catch (final IOException exception) {
+      LOGGER.error("IO Error reading line no: {}", lineNo, exception);
       throw new IllegalStateException(exception);
+    }
+
+    CompletableFuture<Void> allFutures =
+        CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]));
+    try {
+      allFutures.get();
+      LOGGER.info("Finished reading type database from: {}", path);
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error("Error while reading type database from: {}", path, e);
     }
   }
 
   @SuppressWarnings("checkstyle:IllegalCatch")
-  private void processLineSafe(final int lineNo, final String line) {
-    try {
-      this.processLine(line);
-    } catch (final RuntimeException exception) {
-      LOGGER.error("Error parsing line {}, line data: {}", lineNo, line);
-      LOGGER.error(exception.getMessage(), exception);
-    }
+  private CompletableFuture<Boolean> processLineSafe(
+      final int lineNo, final String line, final Path path) {
+    CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+
+    threadPool.submit(
+        () -> {
+          try {
+            if (lineNo % 10000 == 0 && LOGGER.isDebugEnabled()) {
+              LOGGER.debug("On line {} of {}", lineNo, path);
+            }
+            this.processLine(line);
+            completableFuture.complete(true);
+          } catch (final Exception exception) {
+            LOGGER.error("Error parsing line {}, line data: {}", lineNo, line);
+            LOGGER.error(exception.getMessage(), exception);
+            completableFuture.complete(false);
+          }
+        });
+
+    return completableFuture;
   }
 
-  private void processLine(final String line) {
+  private void processLine(String line) {
     if (line.trim().startsWith("//")) {
       // Ignore comments.
       return;
     }
 
-    final JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
-    final String instructionStr = obj.get(Instruction.INSTRUCTION.getValue()).getAsString();
-    final Instruction instruction = Instruction.fromValue(instructionStr);
+    final JsonElement jsonTree = JsonParser.parseString(line);
+    final JsonObject obj = jsonTree.getAsJsonObject();
+    final JsonElement instructionObj = obj.get(Instruction.FIELD_NAME);
+    final Instruction instruction = Instruction.fromValue(instructionObj.getAsInt());
+
     switch (instruction) {
       case PRODUCT:
         this.handleProduct(obj);
@@ -296,62 +268,33 @@ public final class JsonDefinitionReader {
         break;
 
       default:
-        break;
+        throw new IllegalStateException(
+            "Unexpected instruction: " + instruction + "\nline: " + line);
     }
   }
 
-  private Gson buildGson() {
-    return new GsonBuilder()
-        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .registerTypeAdapter(TypeString.class, new TypeStringDeserializer())
-        .registerTypeAdapter(ExpressionResultString.class, new ExpressionResultStringDeserializer())
-        .registerTypeAdapter(Instant.class, new InstantDeserializer())
-        .registerTypeAdapter(
-            ExemplarDefinition.Sort.class, new LowerCaseEnumDeserializer<ExemplarDefinition.Sort>())
-        .registerTypeAdapter(
-            MethodDefinition.Modifier.class,
-            new LowerCaseEnumDeserializer<MethodDefinition.Modifier>())
-        .registerTypeAdapter(
-            ProcedureDefinition.Modifier.class,
-            new LowerCaseEnumDeserializer<ProcedureDefinition.Modifier>())
-        .registerTypeAdapter(
-            ParameterDefinition.Modifier.class,
-            new LowerCaseEnumDeserializer<ParameterDefinition.Modifier>())
-        .registerTypeAdapter(ProductDefinition.class, new ProductDefinitionCreator())
-        .registerTypeAdapter(ModuleDefinition.class, new ModuleDefinitionCreator())
-        .registerTypeAdapter(MethodDefinition.class, new MethodDefinitionCreator())
-        .registerTypeAdapter(ProcedureDefinition.class, new ProcedureDefinitionCreator())
-        .registerTypeAdapter(ExemplarDefinition.class, new ExemplarDefinitionCreator())
-        .create();
-  }
-
-  private void handleProduct(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final ProductDefinition definition = gson.fromJson(instruction, ProductDefinition.class);
+  private void handleProduct(final JsonObject obj) {
+    ProductDefinition definition = gson.fromJson(obj, ProductDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleModule(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final ModuleDefinition definition = gson.fromJson(instruction, ModuleDefinition.class);
+  private void handleModule(final JsonObject obj) {
+    ModuleDefinition definition = gson.fromJson(obj, ModuleDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleMagikFile(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final MagikFileDefinition definition = gson.fromJson(instruction, MagikFileDefinition.class);
+  private void handleMagikFile(final JsonObject obj) {
+    final MagikFileDefinition definition = gson.fromJson(obj, MagikFileDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handlePackage(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final PackageDefinition definition = gson.fromJson(instruction, PackageDefinition.class);
+  private void handlePackage(final JsonObject obj) {
+    PackageDefinition definition = gson.fromJson(obj, PackageDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleType(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final ExemplarDefinition definition = gson.fromJson(instruction, ExemplarDefinition.class);
+  private void handleType(final JsonObject obj) {
+    ExemplarDefinition definition = gson.fromJson(obj, ExemplarDefinition.class);
 
     // We are allowed to overwrite definitions which have no location, as these will most likely
     // be the default definitions from DefaultDefinitionsAdder.
@@ -363,47 +306,28 @@ public final class JsonDefinitionReader {
     this.definitionKeeper.add(definition);
   }
 
-  private void handleMethod(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final MethodDefinition definition = gson.fromJson(instruction, MethodDefinition.class);
+  private void handleMethod(final JsonObject obj) {
+    MethodDefinition definition = gson.fromJson(obj, MethodDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleCondition(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final ConditionDefinition definition = gson.fromJson(instruction, ConditionDefinition.class);
+  private void handleCondition(final JsonObject obj) {
+    ConditionDefinition definition = gson.fromJson(obj, ConditionDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleBinaryOperator(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final BinaryOperatorDefinition definition =
-        gson.fromJson(instruction, BinaryOperatorDefinition.class);
+  private void handleBinaryOperator(final JsonObject obj) {
+    BinaryOperatorDefinition definition = gson.fromJson(obj, BinaryOperatorDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleProcedure(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final ProcedureDefinition definition = gson.fromJson(instruction, ProcedureDefinition.class);
+  private void handleProcedure(final JsonObject obj) {
+    ProcedureDefinition definition = gson.fromJson(obj, ProcedureDefinition.class);
     this.definitionKeeper.add(definition);
   }
 
-  private void handleGlobal(final JsonObject instruction) {
-    final Gson gson = this.buildGson();
-    final GlobalDefinition definition = gson.fromJson(instruction, GlobalDefinition.class);
+  private void handleGlobal(final JsonObject obj) {
+    GlobalDefinition definition = gson.fromJson(obj, GlobalDefinition.class);
     this.definitionKeeper.add(definition);
-  }
-
-  /**
-   * Read types from a JSON-line file.
-   *
-   * @param path Path to JSON-line file.
-   * @param definitionKeeper {@link IDefinitionKeeper} to fill.
-   * @throws IOException -
-   */
-  public static void readTypes(final Path path, final IDefinitionKeeper definitionKeeper)
-      throws IOException {
-    final JsonDefinitionReader reader = new JsonDefinitionReader(definitionKeeper);
-    reader.run(path);
   }
 }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionWriter.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionWriter.java
@@ -1,71 +1,25 @@
 package nl.ramsolutions.sw.magik.analysis.definitions.io;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import com.google.gson.*;
+import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Comparator;
-import nl.ramsolutions.sw.magik.analysis.definitions.BinaryOperatorDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ConditionDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.GlobalDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
-import nl.ramsolutions.sw.magik.analysis.definitions.MagikFileDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.MethodDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.PackageDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ParameterDefinition;
-import nl.ramsolutions.sw.magik.analysis.definitions.ProcedureDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.*;
+import nl.ramsolutions.sw.magik.analysis.definitions.io.serializer.*;
 import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
 import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
 import nl.ramsolutions.sw.moduledef.ModuleDefinition;
+import nl.ramsolutions.sw.moduledef.ModuleUsage;
 import nl.ramsolutions.sw.productdef.ProductDefinition;
+import nl.ramsolutions.sw.productdef.ProductUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** JSON-line TypeKeeper writer. */
 public final class JsonDefinitionWriter {
-
-  private static final class TypeStringSerializer implements JsonSerializer<TypeString> {
-
-    @Override
-    public JsonElement serialize(
-        final TypeString src, final Type typeOfSrc, final JsonSerializationContext context) {
-      final String fullString = src.getFullString();
-      return new JsonPrimitive(fullString);
-    }
-  }
-
-  private static final class ExpressionResultStringSerializer
-      implements JsonSerializer<ExpressionResultString> {
-
-    @Override
-    public JsonElement serialize(
-        final ExpressionResultString src,
-        final Type typeOfSrc,
-        final JsonSerializationContext context) {
-      if (src == ExpressionResultString.UNDEFINED) {
-        return new JsonPrimitive(ExpressionResultString.UNDEFINED_SERIALIZED_NAME);
-      }
-
-      final JsonArray result = new JsonArray();
-      src.getTypes().stream().map(TypeString::getFullString).forEach(result::add);
-      return result;
-    }
-  }
 
   private static final class LowerCaseEnumSerializer<E extends Enum<?>>
       implements JsonSerializer<E> {
@@ -121,8 +75,6 @@ public final class JsonDefinitionWriter {
 
   private Gson buildGson() {
     return new GsonBuilder()
-        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .registerTypeAdapter(TypeString.class, new TypeStringSerializer())
         .registerTypeAdapter(ExpressionResultString.class, new ExpressionResultStringSerializer())
         .registerTypeAdapter(Instant.class, new InstantSerializer())
         .registerTypeAdapter(
@@ -136,6 +88,23 @@ public final class JsonDefinitionWriter {
         .registerTypeAdapter(
             ParameterDefinition.Modifier.class,
             new LowerCaseEnumSerializer<ParameterDefinition.Modifier>())
+        .registerTypeAdapter(
+            BinaryOperatorDefinition.class, new BinaryOperatorDefinitionSerializer())
+        .registerTypeAdapter(ConditionDefinition.class, new ConditionDefinitionSerializer())
+        .registerTypeAdapter(ExemplarDefinition.class, new ExemplarDefinitionSerializer())
+        .registerTypeAdapter(ExpressionResultString.class, new ExpressionResultStringSerializer())
+        .registerTypeAdapter(GlobalDefinition.class, new GlobalDefinitionSerializer())
+        .registerTypeAdapter(MethodDefinition.class, new MethodDefinitionSerializer())
+        .registerTypeAdapter(ModuleUsage.class, new ModuleUsageSerializer())
+        .registerTypeAdapter(PackageDefinition.class, new PackageDefinitionSerializer())
+        .registerTypeAdapter(ParameterDefinition.class, new ParameterDefinitionSerializer())
+        .registerTypeAdapter(ProcedureDefinition.class, new ProcedureDefinitionSerializer())
+        .registerTypeAdapter(ProductDefinition.class, new ProductDefinitionSerializer())
+        .registerTypeAdapter(ProductUsage.class, new ProductUsageSerializer())
+        .registerTypeAdapter(SlotDefinition.class, new SlotDefinitionSerializer())
+        .registerTypeAdapter(TypeString.class, new TypeStringSerializer())
+        .registerTypeAdapter(ModuleDefinition.class, new ModuleDefinitionSerializer())
+        .registerTypeAdapter(MagikFileDefinition.class, new MagikFileDefinitionSerializer())
         .create();
   }
 
@@ -157,8 +126,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.PRODUCT.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.PRODUCT.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -171,8 +139,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.MODULE.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.MODULE.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -186,8 +153,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.MAGIK_FILE.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.MAGIK_FILE.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -200,8 +166,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.PACKAGE.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.PACKAGE.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -215,8 +180,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.TYPE.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.TYPE.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -233,8 +197,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.METHOD.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.METHOD.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -248,8 +211,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.METHOD.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.METHOD.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -263,8 +225,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.CONDITION.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.CONDITION.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -285,7 +246,7 @@ public final class JsonDefinitionWriter {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
               instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.BINARY_OPERATOR.getValue());
+                  Instruction.FIELD_NAME, Instruction.BINARY_OPERATOR.getValue());
               this.writeInstruction(writer, instruction);
             });
   }
@@ -299,8 +260,7 @@ public final class JsonDefinitionWriter {
             definition -> {
               final Gson gson = this.buildGson();
               final JsonObject instruction = (JsonObject) gson.toJsonTree(definition);
-              instruction.addProperty(
-                  Instruction.INSTRUCTION.getValue(), Instruction.GLOBAL.getValue());
+              instruction.addProperty(Instruction.FIELD_NAME, Instruction.GLOBAL.getValue());
               this.writeInstruction(writer, instruction);
             });
   }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/BaseDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/BaseDeserializer.java
@@ -1,0 +1,203 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.*;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import nl.ramsolutions.sw.MagikToolsProperties;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.MagikFile;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.helpers.Memoizer;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public abstract class BaseDeserializer<T> implements JsonDeserializer<T> {
+  private static final Memoizer<Path, IndexedFile> parsedFiles =
+      new Memoizer<>(BaseDeserializer::computeParsedFile);
+
+  private final List<PathMapping> mappings;
+  private static MagikToolsProperties properties = new MagikToolsProperties();
+
+  private static final Long EMPTY_INDEXED_AT = -1L;
+  private static final IndexedFile EMPTY_INDEXED_FILE =
+      new IndexedFile(Collections.emptyList(), EMPTY_INDEXED_AT);
+
+  public static void setProperties(MagikToolsProperties properties) {
+    BaseDeserializer.properties = properties;
+  }
+
+  private record IndexedFile(List<MagikDefinition> definitions, long indexedAt) {}
+
+  public BaseDeserializer(List<PathMapping> mappings) {
+    this.mappings = Collections.unmodifiableList(mappings);
+  }
+
+  @Nullable
+  public static String nullableString(JsonObject el, String field) {
+    JsonElement strNode = el.get(field);
+    return asString(strNode);
+  }
+
+  @Nullable
+  public static String asString(JsonElement el) {
+    if (el == null || el.isJsonNull() || !el.isJsonPrimitive()) {
+      return null;
+    }
+    return el.getAsString();
+  }
+
+  public static Stream<JsonElement> getStream(JsonObject node, String field) {
+    JsonElement arrNode = node.get(field);
+    if (arrNode == null || !arrNode.isJsonArray()) {
+      return Stream.empty();
+    }
+    JsonArray arr = arrNode.getAsJsonArray();
+
+    return arr.asList().stream();
+  }
+
+  public static <X> List<X> getList(
+      JsonDeserializationContext context, JsonObject node, String field, Class<X> clazz) {
+    return getStream(node, field)
+        .map(e -> context.deserialize(e, clazz))
+        .filter(clazz::isInstance)
+        .map(clazz::cast)
+        .toList();
+  }
+
+  public static <X> Set<X> getSet(
+      JsonDeserializationContext context, JsonObject node, String field, Class<X> clazz) {
+    return getStream(node, field)
+        .map(e -> context.deserialize(e, clazz))
+        .filter(clazz::isInstance)
+        .map(clazz::cast)
+        .collect(Collectors.toSet());
+  }
+
+  @CheckForNull
+  public Location getLocation(JsonObject node) {
+    String source = nullableString(node, "src");
+    if (source != null) {
+      return parseLocation(source);
+    }
+    return null;
+  }
+
+  @CheckForNull
+  public Location parseLocation(String pathStr) {
+    Location location = null;
+
+    if (pathStr != null) {
+      Path path = Path.of(pathStr);
+      location = Location.validLocation(new Location(path.toUri()), this.mappings);
+    }
+
+    return location;
+  }
+
+  @CheckForNull
+  public Location parseUri(String uriStr) {
+    Location location = null;
+
+    if (uriStr != null) {
+      final URI uri = URI.create(uriStr);
+      location = Location.validLocation(new Location(uri), this.mappings);
+    }
+
+    return location;
+  }
+
+  public static String getStringField(JsonObject node, String field) {
+    JsonElement strNode = node.get(field);
+    try {
+      return getString(strNode);
+    } catch (IllegalStateException ex) {
+      throw new RuntimeException("Missing required field " + field);
+    }
+  }
+
+  public static String getString(JsonElement node) {
+    String str = asString(node);
+    if (str == null) {
+      throw new IllegalStateException("Missing required string node " + node);
+    }
+    return str;
+  }
+
+  public static TypeString getTypeString(
+      JsonDeserializationContext context, JsonObject node, String field) {
+    return get(context, node, field, TypeString.class);
+  }
+
+  public static <X> X get(
+      JsonDeserializationContext context, JsonObject node, String field, Class<X> clazz) {
+    return context.deserialize(node.get(field), clazz);
+  }
+
+  public static List<MagikDefinition> getDefinitions(Location location) {
+    if (location == null) {
+      return Collections.emptyList();
+    }
+
+    Path path = location.getPath();
+    try {
+      return parsedFiles.compute(path).definitions;
+    } catch (InterruptedException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  public static <X> MagikDefinition getParsedDefinition(
+      Location location, String name, Class<X> clazz) {
+    return getDefinitions(location).stream()
+        .filter(def -> def.getName().endsWith(name) && clazz.isInstance(def))
+        .findFirst()
+        .orElse(null);
+  }
+
+  public static void clearParsedFiles() {
+    parsedFiles.clear();
+  }
+
+  public static Instant getTimestamp(@Nullable Location location) {
+    if (location == null) {
+      return null;
+    }
+
+    Path path = location.getPath();
+    if (Files.exists(path)) {
+      try {
+        return Files.getLastModifiedTime(path).toInstant();
+      } catch (IOException e) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  private static IndexedFile computeParsedFile(Path path) {
+    if (Files.notExists(path)) {
+      return EMPTY_INDEXED_FILE;
+    }
+
+    long now = System.currentTimeMillis();
+
+    try {
+      MagikFile file = new MagikFile(BaseDeserializer.properties, path);
+      return new IndexedFile(file.getMagikDefinitions(), now);
+    } catch (Exception e) {
+      return EMPTY_INDEXED_FILE;
+    }
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/BinaryOperatorDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/BinaryOperatorDefinitionDeserializer.java
@@ -1,0 +1,45 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.BinaryOperatorDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class BinaryOperatorDefinitionDeserializer
+    extends DefinitionDeserializer<BinaryOperatorDefinition> {
+  public BinaryOperatorDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public BinaryOperatorDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    String operator = getStringField(obj, "op");
+
+    TypeString lhsTypeName = getTypeString(context, obj, "lhs_type_n");
+    TypeString rhsTypeName = getTypeString(context, obj, "rhs_type_n");
+    TypeString resultTypeName = getTypeString(context, obj, "res_type_n");
+
+    return new BinaryOperatorDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        operator,
+        lhsTypeName,
+        rhsTypeName,
+        resultTypeName);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ConditionDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ConditionDefinitionDeserializer.java
@@ -1,0 +1,40 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.ConditionDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+
+public class ConditionDefinitionDeserializer extends DefinitionDeserializer<ConditionDefinition> {
+  public ConditionDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ConditionDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    String name = getStringField(obj, "name");
+    String parent = nullableString(obj, "par");
+    List<String> dataNames = getList(context, obj, "d_names", String.class);
+
+    return new ConditionDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        name,
+        parent,
+        dataNames);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/DefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/DefinitionDeserializer.java
@@ -1,0 +1,57 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonObject;
+import com.sonar.sslr.api.AstNode;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.List;
+import nl.ramsolutions.sw.IDefinition;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+
+public abstract class DefinitionDeserializer<T> extends BaseDeserializer<T> {
+  public DefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  public static class DeserializedDefinition extends MagikDefinition {
+    /**
+     * Constructor.
+     *
+     * @param location Location.
+     * @param moduleName Name of the module this definition resides in.
+     * @param doc Doc.
+     * @param node Node.
+     */
+    protected DeserializedDefinition(
+        @Nullable Location location,
+        @Nullable Instant timestamp,
+        @Nullable String moduleName,
+        @Nullable String doc,
+        @Nullable AstNode node) {
+      super(location, timestamp, moduleName, doc, node);
+    }
+
+    @Override
+    public String getName() {
+      return null;
+    }
+
+    @Override
+    public IDefinition getBareDefinition() {
+      return new DeserializedDefinition(
+          this.getLocation(), this.getTimestamp(), this.getModuleName(), this.getDoc(), null);
+    }
+  }
+
+  public MagikDefinition getDefinition(JsonObject obj) {
+    Location location = getLocation(obj);
+    return new DeserializedDefinition(
+        location,
+        getTimestamp(location),
+        nullableString(obj, "mod_n"),
+        nullableString(obj, "doc"),
+        null);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ExemplarDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ExemplarDefinitionDeserializer.java
@@ -1,0 +1,57 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.SlotDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class ExemplarDefinitionDeserializer extends DefinitionDeserializer<ExemplarDefinition> {
+  public ExemplarDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ExemplarDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+    TypeString typeName = getTypeString(context, obj, "type_n");
+
+    ExemplarDefinition.Sort sort = get(context, obj, "sort", ExemplarDefinition.Sort.class);
+    List<SlotDefinition> slots = getList(context, obj, "slots", SlotDefinition.class);
+    List<TypeString> parents = getList(context, obj, "par", TypeString.class);
+    Set<String> topics = getSet(context, obj, "top", String.class);
+
+    Location location = base.getLocation();
+    if (location != null) {
+      MagikDefinition parsed =
+          getParsedDefinition(location, typeName.getFullString(), ExemplarDefinition.class);
+      if (parsed != null) {
+        location = parsed.getLocation();
+      }
+    }
+
+    return new ExemplarDefinition(
+        location,
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        null,
+        sort,
+        typeName,
+        slots,
+        parents,
+        topics);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ExpressionResultStringDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ExpressionResultStringDeserializer.java
@@ -1,0 +1,44 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Objects;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+import nl.ramsolutions.sw.magik.parser.TypeStringParser;
+
+public class ExpressionResultStringDeserializer extends BaseDeserializer<ExpressionResultString> {
+  public ExpressionResultStringDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ExpressionResultString deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    String str = asString(json);
+    if (str != null) {
+      if (str.equals(ExpressionResultString.UNDEFINED_SERIALIZED_NAME)) {
+        return ExpressionResultString.UNDEFINED;
+      }
+
+      return new ExpressionResultString(TypeStringParser.parseTypeString(str));
+    } else if (json.isJsonArray()) {
+      JsonArray jsonArray = json.getAsJsonArray();
+      final List<TypeString> types =
+          jsonArray.asList().stream()
+              .map(BaseDeserializer::asString)
+              .filter(Objects::nonNull)
+              .map(TypeStringParser::parseTypeString)
+              .toList();
+      return new ExpressionResultString(types);
+    } else {
+      return ExpressionResultString.EMPTY;
+    }
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/GlobalDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/GlobalDefinitionDeserializer.java
@@ -1,0 +1,39 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.GlobalDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class GlobalDefinitionDeserializer extends DefinitionDeserializer<GlobalDefinition> {
+  public GlobalDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public GlobalDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    TypeString typeName = getTypeString(context, obj, "type_n");
+    TypeString aliasedTypeName = getTypeString(context, obj, "alias_type_n");
+
+    return new GlobalDefinition(
+        base.getLocation(),
+        getTimestamp(base.getLocation()),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        typeName,
+        aliasedTypeName);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/LowerCaseEnumDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/LowerCaseEnumDeserializer.java
@@ -1,0 +1,32 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+
+public class LowerCaseEnumDeserializer<E extends Enum<?>> extends BaseDeserializer<E> {
+  private final E[] constants;
+
+  public LowerCaseEnumDeserializer(List<PathMapping> mappings, Class<E> clazz) {
+    super(mappings);
+    if (!clazz.isEnum()) {
+      throw new IllegalArgumentException("Class must be an enum");
+    }
+
+    this.constants = clazz.getEnumConstants();
+  }
+
+  @Override
+  public E deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final String value = json.getAsString().toUpperCase();
+    return Arrays.stream(constants)
+        .filter(c -> c.toString().equals(value))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/MagikFileDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/MagikFileDefinitionDeserializer.java
@@ -1,0 +1,34 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikFileDefinition;
+
+public class MagikFileDefinitionDeserializer extends DefinitionDeserializer<MagikFileDefinition> {
+  public MagikFileDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public MagikFileDefinition deserialize(
+      JsonElement json, Type type, JsonDeserializationContext context) throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    JsonObject srcObj = obj.getAsJsonObject("src");
+    if (srcObj == null || !srcObj.isJsonObject() || !srcObj.has("uri")) {
+      throw new JsonParseException("src.uri for magik file is missing");
+    }
+    Location loc = parseUri(getStringField(srcObj, "uri"));
+    if (loc == null) {
+      throw new JsonParseException("src.uri for a magik file can't be parsed");
+    }
+
+    return new MagikFileDefinition(loc, null);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/MethodDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/MethodDefinitionDeserializer.java
@@ -1,0 +1,84 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.*;
+import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class MethodDefinitionDeserializer extends DefinitionDeserializer<MethodDefinition> {
+  public MethodDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public MethodDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    TypeString typeName = getTypeString(context, obj, "type_n");
+    String methodName = getStringField(obj, "m_name");
+
+    Location location = base.getLocation();
+    if (location != null) {
+      MagikDefinition parsed = getParsedDefinition(location, methodName, MethodDefinition.class);
+      if (parsed != null) {
+        location = parsed.getLocation();
+      }
+    }
+
+    Set<MethodDefinition.Modifier> modifiers =
+        getSet(context, obj, "mods", MethodDefinition.Modifier.class);
+    List<ParameterDefinition> parameters =
+        getList(context, obj, "params", ParameterDefinition.class);
+
+    ParameterDefinition assignmentParameter =
+        get(context, obj, "a_param", ParameterDefinition.class);
+
+    Set<String> topics = getSet(context, obj, "top", String.class);
+
+    // if no return type is defined check for new* or init*
+    //   -> assume the method returns an object of the same exemplar
+    ExpressionResultString returnTypes = get(context, obj, "ret", ExpressionResultString.class);
+    if ((methodName.startsWith("new") || methodName.startsWith("init"))
+        && returnTypes.equals(ExpressionResultString.UNDEFINED)) {
+      returnTypes = new ExpressionResultString(typeName);
+    }
+
+    ExpressionResultString loopTypes = get(context, obj, "loop", ExpressionResultString.class);
+
+    List<GlobalUsage> usedGlobals = getList(context, obj, "u_globals", GlobalUsage.class);
+    List<MethodUsage> usedMethods = getList(context, obj, "u_methods", MethodUsage.class);
+    List<SlotUsage> usedSlots = getList(context, obj, "u_slots", SlotUsage.class);
+    List<ConditionUsage> usedConditions = getList(context, obj, "u_conds", ConditionUsage.class);
+
+    return new MethodDefinition(
+        location,
+        getTimestamp(location),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        typeName,
+        methodName,
+        modifiers,
+        parameters,
+        assignmentParameter,
+        topics,
+        returnTypes,
+        loopTypes,
+        usedGlobals,
+        usedMethods,
+        usedSlots,
+        usedConditions);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ModuleDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ModuleDefinitionDeserializer.java
@@ -1,0 +1,36 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.moduledef.ModuleDefinition;
+import nl.ramsolutions.sw.moduledef.ModuleUsage;
+
+public class ModuleDefinitionDeserializer extends BaseDeserializer<ModuleDefinition> {
+  public ModuleDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ModuleDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    String name = getStringField(obj, "name");
+    String baseVersion = getStringField(obj, "base_ver");
+    String currentVersion = nullableString(obj, "cur_ver");
+    String product = nullableString(obj, "prod");
+    List<ModuleUsage> usages = getList(context, obj, "usgs", ModuleUsage.class);
+
+    Location location = getLocation(obj);
+
+    return new ModuleDefinition(
+        location, getTimestamp(location), name, product, baseVersion, currentVersion, null, usages);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ModuleUsageDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ModuleUsageDeserializer.java
@@ -1,0 +1,24 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.moduledef.ModuleUsage;
+
+public class ModuleUsageDeserializer extends BaseDeserializer<ModuleUsage> {
+  public ModuleUsageDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ModuleUsage deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+    String name = getStringField(obj, "name");
+    return new ModuleUsage(name, null);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/PackageDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/PackageDefinitionDeserializer.java
@@ -1,0 +1,38 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.PackageDefinition;
+
+public class PackageDefinitionDeserializer extends DefinitionDeserializer<PackageDefinition> {
+  public PackageDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public PackageDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    String name = getStringField(obj, "name");
+    List<String> uses = getList(context, obj, "uses", String.class);
+
+    return new PackageDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        name,
+        uses);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ParameterDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ParameterDefinitionDeserializer.java
@@ -1,0 +1,43 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.ParameterDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class ParameterDefinitionDeserializer extends DefinitionDeserializer<ParameterDefinition> {
+  public ParameterDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ParameterDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    String name = getStringField(obj, "name");
+
+    ParameterDefinition.Modifier modifier =
+        get(context, obj, "mod", ParameterDefinition.Modifier.class);
+    TypeString typeName = getTypeString(context, obj, "type_n");
+
+    return new ParameterDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        name,
+        modifier,
+        typeName);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/PathDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/PathDeserializer.java
@@ -1,0 +1,28 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+
+public class PathDeserializer extends BaseDeserializer<Path> {
+
+  public PathDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public Path deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    if (!json.isJsonPrimitive() || !json.getAsJsonPrimitive().isString()) {
+      throw new IllegalArgumentException(json + " is not a string");
+    }
+
+    final String value = json.getAsJsonPrimitive().getAsString();
+    return Paths.get(value);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProcedureDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProcedureDefinitionDeserializer.java
@@ -1,0 +1,54 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Set;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.ParameterDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.ProcedureDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class ProcedureDefinitionDeserializer extends DefinitionDeserializer<ProcedureDefinition> {
+  public ProcedureDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ProcedureDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    Set<ProcedureDefinition.Modifier> modifiers =
+        getSet(context, obj, "mods", ProcedureDefinition.Modifier.class);
+    TypeString typeName = getTypeString(context, obj, "type_n");
+
+    String procedureName = nullableString(obj, "proc_name");
+
+    List<ParameterDefinition> parameters =
+        getList(context, obj, "params", ParameterDefinition.class);
+    ExpressionResultString returnTypes = get(context, obj, "ret", ExpressionResultString.class);
+    ExpressionResultString loopTypes = get(context, obj, "loop", ExpressionResultString.class);
+
+    return new ProcedureDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        base.getNode(),
+        modifiers,
+        typeName,
+        procedureName,
+        parameters,
+        returnTypes,
+        loopTypes);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProductDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProductDefinitionDeserializer.java
@@ -1,0 +1,46 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.productdef.ProductDefinition;
+import nl.ramsolutions.sw.productdef.ProductUsage;
+
+public class ProductDefinitionDeserializer extends BaseDeserializer<ProductDefinition> {
+  public ProductDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ProductDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final JsonObject obj = json.getAsJsonObject();
+
+    String name = getStringField(obj, "name");
+    String version = nullableString(obj, "ver");
+    String versionComment = nullableString(obj, "ver_com");
+    String title = nullableString(obj, "title");
+    String description = nullableString(obj, "desc");
+    String parent = nullableString(obj, "parent");
+    List<ProductUsage> usages = getList(context, obj, "usage", ProductUsage.class);
+
+    Location location = getLocation(obj);
+
+    return new ProductDefinition(
+        location,
+        getTimestamp(location),
+        name,
+        parent,
+        version,
+        versionComment,
+        title,
+        description,
+        usages);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProductUsageDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/ProductUsageDeserializer.java
@@ -1,0 +1,25 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.productdef.ProductUsage;
+
+public class ProductUsageDeserializer extends BaseDeserializer<ProductUsage> {
+  public ProductUsageDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public ProductUsage deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final JsonObject obj = json.getAsJsonObject();
+    String name = getStringField(obj, "name");
+    return new ProductUsage(name, null);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/SlotDefinitionDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/SlotDefinitionDeserializer.java
@@ -1,0 +1,39 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.SlotDefinition;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class SlotDefinitionDeserializer extends DefinitionDeserializer<SlotDefinition> {
+  public SlotDefinitionDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public SlotDefinition deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject obj = json.getAsJsonObject();
+
+    MagikDefinition base = getDefinition(obj);
+
+    final String name = getStringField(obj, "name");
+    final TypeString typeName = getTypeString(context, obj, "type_n");
+
+    return new SlotDefinition(
+        base.getLocation(),
+        base.getTimestamp(),
+        base.getModuleName(),
+        base.getDoc(),
+        null,
+        name,
+        typeName);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/TypeStringDeserializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/deserializer/TypeStringDeserializer.java
@@ -1,0 +1,23 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.List;
+import nl.ramsolutions.sw.magik.PathMapping;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+import nl.ramsolutions.sw.magik.parser.TypeStringParser;
+
+public final class TypeStringDeserializer extends BaseDeserializer<TypeString> {
+  public TypeStringDeserializer(List<PathMapping> mappings) {
+    super(mappings);
+  }
+
+  @Override
+  public TypeString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    final String identifier = getString(json);
+    return TypeStringParser.parseTypeString(identifier);
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/BaseSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/BaseSerializer.java
@@ -1,0 +1,26 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikDefinition;
+
+public abstract class BaseSerializer<T> implements JsonSerializer<T> {
+  public static void field(
+      JsonObject obj, JsonSerializationContext ctx, String fieldName, @Nullable Object value) {
+    obj.add(fieldName, ctx.serialize(value));
+  }
+
+  public static void location(JsonObject obj, JsonSerializationContext ctx, Location location) {
+    field(obj, ctx, "src", location);
+  }
+
+  public static void addDefinition(
+      JsonObject obj, JsonSerializationContext ctx, MagikDefinition definition) {
+    location(obj, ctx, definition.getLocation());
+    field(obj, ctx, "mod_n", definition.getModuleName());
+    field(obj, ctx, "doc", definition.getDoc());
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/BinaryOperatorDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/BinaryOperatorDefinitionSerializer.java
@@ -1,0 +1,24 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.BinaryOperatorDefinition;
+
+public class BinaryOperatorDefinitionSerializer extends BaseSerializer<BinaryOperatorDefinition> {
+  @Override
+  public JsonElement serialize(
+      BinaryOperatorDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "op", src.getOperator());
+    field(obj, context, "lhs_type_n", src.getLhsTypeName());
+    field(obj, context, "rhs_type_n", src.getRhsTypeName());
+    field(obj, context, "res_type_n", src.getResultTypeName());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ConditionDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ConditionDefinitionSerializer.java
@@ -1,0 +1,23 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.ConditionDefinition;
+
+public class ConditionDefinitionSerializer extends BaseSerializer<ConditionDefinition> {
+  @Override
+  public JsonElement serialize(
+      ConditionDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "par", src.getParent());
+    field(obj, context, "d_names", src.getDataNames());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ExemplarDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ExemplarDefinitionSerializer.java
@@ -1,0 +1,24 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
+
+public class ExemplarDefinitionSerializer extends BaseSerializer<ExemplarDefinition> {
+  @Override
+  public JsonElement serialize(
+      ExemplarDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "type_n", src.getTypeString());
+    field(obj, context, "sort", src.getSort());
+    field(obj, context, "slots", src.getSlots());
+    field(obj, context, "par", src.getParents());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ExpressionResultStringSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ExpressionResultStringSerializer.java
@@ -1,0 +1,34 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class ExpressionResultStringSerializer extends BaseSerializer<ExpressionResultString> {
+  @Override
+  public JsonElement serialize(
+      ExpressionResultString src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonElement element;
+
+    if (src.equals(ExpressionResultString.EMPTY)) {
+      element = new JsonPrimitive("");
+    } else if (src.equals(ExpressionResultString.UNDEFINED)) {
+      element = new JsonPrimitive(ExpressionResultString.UNDEFINED_SERIALIZED_NAME);
+    } else if (src.size() > 1) {
+      JsonArray array = new JsonArray(src.size());
+
+      src.stream()
+          .forEach(typeString -> array.add(context.serialize(typeString, TypeString.class)));
+
+      element = array;
+    } else {
+      element = new JsonPrimitive(src.get(0, TypeString.UNDEFINED).getFullString());
+    }
+
+    return element;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/GlobalDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/GlobalDefinitionSerializer.java
@@ -1,0 +1,22 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.GlobalDefinition;
+
+public class GlobalDefinitionSerializer extends BaseSerializer<GlobalDefinition> {
+  @Override
+  public JsonElement serialize(
+      GlobalDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "type_n", src.getTypeString());
+    field(obj, context, "alias_type_n", src.getAliasedTypeName());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/MagikFileDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/MagikFileDefinitionSerializer.java
@@ -1,0 +1,21 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.MagikFileDefinition;
+
+public class MagikFileDefinitionSerializer extends BaseSerializer<MagikFileDefinition> {
+  @Override
+  public JsonElement serialize(
+      MagikFileDefinition def, Type type, JsonSerializationContext context) {
+    final JsonObject obj = new JsonObject();
+
+    final JsonObject src = new JsonObject();
+    field(src, context, "uri", def.getUri());
+    field(obj, context, "src", src);
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/MethodDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/MethodDefinitionSerializer.java
@@ -1,0 +1,31 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.MethodDefinition;
+
+public class MethodDefinitionSerializer extends BaseSerializer<MethodDefinition> {
+  @Override
+  public JsonElement serialize(
+      MethodDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    final JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "type_n", src.getTypeName());
+    field(obj, context, "m_name", src.getMethodName());
+    field(obj, context, "mods", src.getModifiers());
+    field(obj, context, "params", src.getParameters());
+    field(obj, context, "a_param", src.getAssignmentParameter());
+    field(obj, context, "top", src.getTopics());
+    field(obj, context, "loop", src.getLoopTypes());
+    field(obj, context, "u_globals", src.getUsedGlobals());
+    field(obj, context, "u_methods", src.getUsedMethods());
+    field(obj, context, "u_slots", src.getUsedSlots());
+    field(obj, context, "u_conds", src.getUsedConditions());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ModuleDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ModuleDefinitionSerializer.java
@@ -1,0 +1,24 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.moduledef.ModuleDefinition;
+
+public class ModuleDefinitionSerializer extends BaseSerializer<ModuleDefinition> {
+  @Override
+  public JsonElement serialize(
+      ModuleDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "base_ver", src.getBaseVersion());
+    field(obj, context, "cur_ver", src.getBaseVersion());
+    field(obj, context, "prod", src.getProduct());
+    field(obj, context, "usgs", src.getUsages());
+    location(obj, context, src.getLocation());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ModuleUsageSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ModuleUsageSerializer.java
@@ -1,0 +1,16 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.moduledef.ModuleUsage;
+
+public class ModuleUsageSerializer extends BaseSerializer<ModuleUsage> {
+  @Override
+  public JsonElement serialize(ModuleUsage src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+    field(obj, context, "name", src.getName());
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/PackageDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/PackageDefinitionSerializer.java
@@ -1,0 +1,22 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.PackageDefinition;
+
+public class PackageDefinitionSerializer extends BaseSerializer<PackageDefinition> {
+  @Override
+  public JsonElement serialize(
+      PackageDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "uses", src.getUses());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ParameterDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ParameterDefinitionSerializer.java
@@ -1,0 +1,23 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.ParameterDefinition;
+
+public class ParameterDefinitionSerializer extends BaseSerializer<ParameterDefinition> {
+  @Override
+  public JsonElement serialize(
+      ParameterDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "mod", src.getModifier());
+    field(obj, context, "type_n", src.getTypeName());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProcedureDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProcedureDefinitionSerializer.java
@@ -1,0 +1,26 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.ProcedureDefinition;
+
+public class ProcedureDefinitionSerializer extends BaseSerializer<ProcedureDefinition> {
+  @Override
+  public JsonElement serialize(
+      ProcedureDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "mods", src.getModifiers());
+    field(obj, context, "type_n", src.getTypeString());
+    field(obj, context, "proc_name", src.getProcedureName());
+    field(obj, context, "params", src.getParameters());
+    field(obj, context, "ret", src.getReturnTypes());
+    field(obj, context, "loop", src.getLoopTypes());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProductDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProductDefinitionSerializer.java
@@ -1,0 +1,25 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.productdef.ProductDefinition;
+
+public class ProductDefinitionSerializer extends BaseSerializer<ProductDefinition> {
+  @Override
+  public JsonElement serialize(
+      ProductDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    location(obj, context, src.getLocation());
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "ver", src.getVersion());
+    field(obj, context, "ver_com", src.getVersionComment());
+    field(obj, context, "parent", src.getParent());
+    field(obj, context, "usage", src.getUsages());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProductUsageSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/ProductUsageSerializer.java
@@ -1,0 +1,18 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.productdef.ProductUsage;
+
+public class ProductUsageSerializer extends BaseSerializer<ProductUsage> {
+  @Override
+  public JsonElement serialize(ProductUsage src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    field(obj, context, "name", src.getName());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/SlotDefinitionSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/SlotDefinitionSerializer.java
@@ -1,0 +1,22 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.definitions.SlotDefinition;
+
+public class SlotDefinitionSerializer extends BaseSerializer<SlotDefinition> {
+  @Override
+  public JsonElement serialize(
+      SlotDefinition src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject obj = new JsonObject();
+
+    addDefinition(obj, context, src);
+
+    field(obj, context, "name", src.getName());
+    field(obj, context, "type_n", src.getTypeName());
+
+    return obj;
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/TypeStringSerializer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/io/serializer/TypeStringSerializer.java
@@ -1,0 +1,14 @@
+package nl.ramsolutions.sw.magik.analysis.definitions.io.serializer;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import java.lang.reflect.Type;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+
+public class TypeStringSerializer extends BaseSerializer<TypeString> {
+  @Override
+  public JsonElement serialize(TypeString src, Type typeOfSrc, JsonSerializationContext context) {
+    return new JsonPrimitive(src.getFullString());
+  }
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/Computable.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/Computable.java
@@ -1,0 +1,5 @@
+package nl.ramsolutions.sw.magik.analysis.helpers;
+
+public interface Computable<A, V> {
+  V compute(A arg) throws InterruptedException;
+}

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/Memoizer.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/Memoizer.java
@@ -1,0 +1,62 @@
+package nl.ramsolutions.sw.magik.analysis.helpers;
+
+import java.util.concurrent.*;
+
+/**
+ * memoize expensive calls and make sure that they do not get called twice by two/multiple threads
+ * TODO include recompute filter computable?
+ *
+ * <p>Source:
+ *
+ * <ul>
+ *   <li><a href="https://stackoverflow.com/a/2348533">StackOverflow post</a>
+ *   <li><a
+ *       href="https://www.javaspecialists.eu/archive/Issue125-Book-Review-Java-Concurrency-in-Practice.html">Book
+ *       Review: Java Concurrency in Practice</a>
+ * </ul>
+ *
+ * @param <A> the key for the map to compute from
+ * @param <V> the type of the computed value
+ */
+public class Memoizer<A, V> implements Computable<A, V> {
+  private final ConcurrentMap<A, Future<V>> cache = new ConcurrentHashMap<>();
+  private final Computable<A, V> c;
+
+  public Memoizer(Computable<A, V> c) {
+    this.c = c;
+  }
+
+  public V compute(final A arg) throws InterruptedException {
+    while (true) {
+      Future<V> f = cache.get(arg);
+      if (f == null) {
+        Callable<V> eval = () -> c.compute(arg);
+        FutureTask<V> ft = new FutureTask<>(eval);
+        f = cache.putIfAbsent(arg, ft);
+        if (f == null) {
+          f = ft;
+          ft.run();
+        }
+      }
+      try {
+        return f.get();
+      } catch (CancellationException e) {
+        cache.remove(arg, f);
+      } catch (ExecutionException e) {
+        // Kabutz: this is my addition to the code...
+        try {
+          throw e.getCause();
+        } catch (RuntimeException | Error ex) {
+          throw ex;
+        } catch (Throwable t) {
+          throw new IllegalStateException("Not unchecked", t);
+        }
+      }
+    }
+  }
+
+  public void clear() {
+    this.cache.forEach((k, v) -> v.cancel(true));
+    this.cache.clear();
+  }
+}

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionReaderTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/definitions/io/JsonDefinitionReaderTest.java
@@ -2,7 +2,6 @@ package nl.ramsolutions.sw.magik.analysis.definitions.io;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -10,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import nl.ramsolutions.sw.magik.Location;
+import nl.ramsolutions.sw.magik.Position;
+import nl.ramsolutions.sw.magik.Range;
 import nl.ramsolutions.sw.magik.analysis.definitions.BinaryOperatorDefinition;
 import nl.ramsolutions.sw.magik.analysis.definitions.ConditionDefinition;
 import nl.ramsolutions.sw.magik.analysis.definitions.DefinitionKeeper;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
 /** Tests for JsonDefinitionReader. */
 class JsonDefinitionReaderTest {
 
-  private IDefinitionKeeper readTypes() throws IOException {
+  private IDefinitionKeeper readTypes() {
     final Path path = Path.of("src/test/resources/tests/type_database.jsonl");
     final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
     JsonDefinitionReader.readTypes(path, definitionKeeper);
@@ -38,7 +39,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadProduct() throws IOException {
+  void testReadProduct() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<ProductDefinition> productDefs =
@@ -61,7 +62,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadModule() throws IOException {
+  void testReadModule() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<ModuleDefinition> moduleDefs =
@@ -83,7 +84,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadMagikFile() throws IOException {
+  void testReadMagikFile() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<MagikFileDefinition> magikFileDefs =
@@ -92,11 +93,16 @@ class JsonDefinitionReaderTest {
 
     final MagikFileDefinition magikFileDef = magikFileDefs.stream().findAny().orElseThrow();
     assertThat(magikFileDef)
-        .isEqualTo(new MagikFileDefinition(new Location(URI.create("file:///test.magik")), null));
+        .isEqualTo(
+            new MagikFileDefinition(
+                new Location(
+                    URI.create("file:///test.magik"),
+                    new Range(new Position(1, 0), new Position(1, 0))),
+                null));
   }
 
   @Test
-  void testReadPackage() throws IOException {
+  void testReadPackage() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<PackageDefinition> testPackageDefs =
@@ -110,7 +116,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadType() throws IOException {
+  void testReadType() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final TypeString aRef = TypeString.ofIdentifier("a", "user");
@@ -136,7 +142,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadMethod() throws IOException {
+  void testReadMethod() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final TypeString bRef = TypeString.ofIdentifier("user:b", "user");
@@ -209,7 +215,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadCondition() throws IOException {
+  void testReadCondition() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<ConditionDefinition> conditionsError =
@@ -242,7 +248,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadGlobal() throws IOException {
+  void testReadGlobal() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final TypeString tabCharRef = TypeString.ofIdentifier("tab_char", "sw");
@@ -271,7 +277,7 @@ class JsonDefinitionReaderTest {
   }
 
   @Test
-  void testReadBinaryOperator() throws IOException {
+  void testReadBinaryOperator() {
     final IDefinitionKeeper definitionKeeper = this.readTypes();
 
     final Collection<BinaryOperatorDefinition> binOps =

--- a/magik-squid/src/test/resources/tests/type_database.jsonl
+++ b/magik-squid/src/test/resources/tests/type_database.jsonl
@@ -3,29 +3,29 @@
 // undefined type: _undefined
 // undefined result: __UNDEFINED_RESULT__
 // products
-{"instruction":"product","name":"test_product","version":"1.0.0","title":"Test product","description":"Test product"}
+{"i": 1,"name":"test_product","ver":"1.0.0","title":"Test product","desc":"Test product"}
 // modules
-{"instruction":"module","name":"test_module","base_version":"1","current_version":"2","product_name":"test_product","description":"test_module"}
+{"i":2,"name":"test_module","base_ver":"1","cur_ver":"2","p_name":"test_product","desc":"test_module"}
 // magik files
-{"instruction":"magik_file","location":{"uri":"file:///test.magik"}}
+{"i":10, "src":{"uri":"file:///test.magik"}}
 // packages
-{"instruction":"package","name":"sw","uses":[]}
-{"instruction":"package","name":"user","uses":["sw"]}
-{"instruction":"package","name":"test_package","uses":["user"]}
+{"i": 3,"name":"sw","uses":[]}
+{"i":3,"name":"user","uses":["sw"]}
+{"i":3,"name":"test_package","uses":["user"]}
 // types
-{"instruction":"type","type_name":"user:a","sort":"slotted","doc":"Test exemplar a","parents":["sw:object"],"slots":[{"name":"slot1","type_name":"sw:integer"},{"name":"slot2","type_name":"sw:float"}],"module_name":"test_module"}
-{"instruction":"type","type_name":"user:b","sort":"indexed","doc":"Test exemplar b","parents":["sw:object"],"slots":[],"module_name":null}
+{"i":4,"type_n":"user:a","sort":"slotted","doc":"Test exemplar a","par":["sw:object"],"slots":[{"name":"slot1","type_n":"sw:integer"},{"name":"slot2","type_n":"sw:float"}],"mod_n":"test_module"}
+{"i":4,"type_n":"user:b","sort":"indexed","doc":"Test exemplar b","par":["sw:object"],"slots":[],"mod_n":null}
 // globals
-{"instruction":"global","type_name":"sw:!print_float_precision!","aliased_type_name":"sw:integer"}
-{"instruction":"global","type_name":"sw:tab_char","aliased_type_name":"sw:character"}
+{"i":5,"type_n":"sw:!print_float_precision!","alias_type_n":"sw:integer"}
+{"i":5,"type_n":"sw:tab_char","alias_type_n":"sw:character"}
 // methods
-{"instruction":"method","type_name":"user:b","method_name":"m1()","modifiers":[],"parameters":[{"name":"param1","modifier":"gather","type_name":"sw:symbol"},{"name":"param2","modifier":"none","type_name":"_undefined"}],"return_types":["sw:symbol"],"loop_types":[],"source_file":null,"doc":"Test method m1()","module_name":"test_module"}
-{"instruction":"method","type_name":"user:b","method_name":"m2<<","modifiers":["private"],"parameters":[],"assignment_parameter":{"name":"param2","modifier":"none","type_name":"sw:symbol"},"return_types":["sw:symbol"],"loop_types":[],"source_file":null,"doc":"Test method m2()","module_name":"test_module"}
+{"i":6,"type_n":"user:b","m_name":"m1()","mods":[],"params":[{"name":"param1","mod":"gather","type_n":"sw:symbol"},{"name":"param2","mod":"none","type_n":"_undefined"}],"ret":["sw:symbol"],"loop":[],"src":null,"doc":"Test method m1()","mod_n":"test_module"}
+{"i":6,"type_n":"user:b","m_name":"m2<<","mods":["private"],"params":[],"a_param":{"name":"param2","mod":"none","type_n":"sw:symbol"},"ret":["sw:symbol"],"loop":[],"src":null,"doc":"Test method m2()","mod_n":"test_module"}
 // procedures
-{"instruction":"procedure","type_name":"sw:quit","procedure_name":"quit","modifiers":[],"parameters":[{"name":"status","modifier":"optional","type_name":"_undefined"}],"return_types":"__UNDEFINED_RESULT__","loop_types":[],"source_file":null,"doc":"Quit!","module_name":"test_module"}
-{"instruction":"procedure","type_name":"sw:range","procedure_name":"range","modifiers":["iter"],"parameters":[{"name":"start","modifier":"none","type_name":"_undefined"},{"name":"end","modifier":"none","type_name":"_undefined"},{"name":"step","modifier":"optional","type_name":"_undefined"}],"return_types":[],"loop_types":["sw:integer"],"source_file":null,"doc":"Range iterator."}
+{"i":7,"type_n":"sw:quit","proc_name":"quit","mods":[],"params":[{"name":"status","mod":"optional","type_n":"_undefined"}],"ret":"__UNDEFINED_RESULT__","loop":[],"src":null,"doc":"Quit!","mod_n":"test_module"}
+{"i":7,"type_n":"sw:range","proc_name":"range","mods":["iter"],"params":[{"name":"start","mod":"none","type_n":"_undefined"},{"name":"end","mod":"none","type_n":"_undefined"},{"name":"step","mod":"optional","type_n":"_undefined"}],"ret":[],"loop":["sw:integer"],"src":null,"doc":"Range iterator."}
 // conditions
-{"instruction":"condition","name":"error","data_names":["string"],"parent":null,"doc":null}
-{"instruction":"condition","name":"unknown_value","data_names":["value","permitted_values"],"parent":"error","doc":"Unknown value"}
+{"i":8,"name":"error","d_names":["string"],"par":null,"doc":null}
+{"i":8,"name":"unknown_value","d_names":["value","permitted_values"],"par":"error","doc":"Unknown value"}
 // binary operators
-{"instruction":"binary_operator","operator":"=","lhs_type_name":"sw:char16_vector","rhs_type_name":"sw:symbol","result_type_name":"sw:char16_vector","module_name":"test_module"}
+{"i":9,"op":"=","lhs_type_n":"sw:char16_vector","rhs_type_n":"sw:symbol","res_type_n":"sw:char16_vector","mod_n":"test_module"}

--- a/sw_type_dumper/magik-lint.properties
+++ b/sw_type_dumper/magik-lint.properties
@@ -1,2 +1,2 @@
-disabled=sw-method-doc
+disabled=sw-method-doc,file-method-count,exemplar-slot-count
 variable-declaration-usage-distance.max-distance=10

--- a/sw_type_dumper/modules/sw_type_dumper/source/datamodel_type_dumper.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/datamodel_type_dumper.magik
@@ -25,6 +25,7 @@ _method datamodel_type_dumper.new(view, filename)
 	## @param {sw:ds_version_view} view
 	## @param {sw:char16_vector} filename filename to dump to
 	## @return {_clone}
+
 	_return _clone.init(view, filename)
 _endmethod
 $
@@ -84,9 +85,9 @@ _private _method datamodel_type_dumper.int!run()
 	## Note that order of export is important when reading this file!
 	# Write intro.
 	_self.write_line("// Smallworld version: ", system.sw!version_string)
-	_self.write_line("// self type: ", _self.self_type)
-	_self.write_line("// undefined type: ", _self.undefined_type)
-	_self.write_line("// undefined result: ", _self.undefined_result)
+	_self.write_line("// self type: ", mt:definition.self_type)
+	_self.write_line("// undefined type: ", mt:definition.undefined_type)
+	_self.write_line("// undefined result: ", mt:definition.undefined_result)
 	_self.write_line("// view: ", .view.original_dataset_name)
 
 	# Keep same structure as type_dumper as the type_merger depends on this.
@@ -114,18 +115,18 @@ _private _method datamodel_type_dumper.int!run()
 			_endif
 
 			_local definition << method_definition.new(
-				type_name,
-				field.name,
-				{},
-				{},
-				_unset,
-				_self.field_type_name(field),
-				{},
-				_unset,
-				field.external_name,
-				_unset,
-				_unset,
-				{})
+					type_name,
+					field.name,
+					rope.new_with("db_type"),
+					{},
+					_unset,
+					_self.field_type_name(field),
+					{},
+					_unset,
+					field.external_name,
+					_unset,
+					_unset,
+					{})
 			_self.write_definition(definition)
 		_endloop
 	_endloop
@@ -162,10 +163,15 @@ _private _method datamodel_type_dumper.ignore_collection?(collection)
 	## @param {sw:ds_collection} collection
 	## @return {sw:false} Ignore?
 	## @return {sw:char16_vector} Ignore reason
+	_if collection _is _unset
+	_then
+		_return _false, ""
+	_endif
+
 	_local rec_ex << collection.record_exemplar
 	_if rec_ex.class_name _is :ds_record _orif
-	    rec_ex.class_name _is :rwo_record _orif
-	    rec_ex.class_name _is :dataless_rwo_record
+		rec_ex.class_name _is :rwo_record _orif
+		rec_ex.class_name _is :dataless_rwo_record
 	_then
 		_return _true, "No record exemplar"
 	_endif
@@ -180,7 +186,12 @@ _private _method datamodel_type_dumper.ignore_field?(field)
 	## @param {sw:ds_field} field
 	## @return {sw:false} Ignore?
 	## @return {sw:char16_vector} Ignore reason
-	_local owner << field.owner
+	_local owner <<
+		_try
+			>> field.owner
+		_when error
+			>> _unset
+		_endtry
 	_local (ignore_collection?, reason_collection) << _self.ignore_collection?(owner)
 	_if ignore_collection?
 	_then
@@ -196,7 +207,7 @@ _private _method datamodel_type_dumper.field_type_name(field)
 	## Get the type name of a field.
 	## @param {sw:ds_field} field
 	## @return {sw:simple_vector<sw:char16_vector>|sw:char16_vector}
-	_local type_name << _self.undefined_type
+	_local type_name << mt:definition.undefined_type
 	_if field.is_physical?
 	_then
 		_local type << field.type.class.class_name
@@ -233,7 +244,7 @@ _private _method datamodel_type_dumper.field_type_name(field)
 		condition.raise(:not_implemented)
 	_endif
 
-	_if type_name = _self.undefined_result
+	_if type_name = mt:definition.undefined_result
 	_then
 		_return type_name
 	_endif
@@ -258,6 +269,6 @@ _private _method datamodel_type_dumper.join_result_type_names(join_field)
 		_local result_type_name << _self.get_type_name_for_collection(result_table)
 		result_type_names.add(result_type_name)
 	_endloop
-	_return result_type_names.join_as_strings(_self.value_combinator)
+	_return result_type_names.join_as_strings(mt:definition.value_combinator)
 _endmethod
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/binary_operator_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/binary_operator_definition.magik
@@ -3,19 +3,27 @@ _package mt
 
 _pragma(classify_level=basic, topic=type_dumper)
 ## Binary oeprator definition.
-## @slot {sw:char16_vector} operator
-## @slot {sw:char16_vector} lhs_type_name
-## @slot {sw:char16_vector} rhs_type_name
-## @slot {sw:char16_vector} result_type_name
+## @slot {sw:char16_vector} op
+## @slot {sw:char16_vector} lhs_type_n
+## @slot {sw:char16_vector} rhs_type_n
+## @slot {sw:char16_vector} res_type_n
 def_slotted_exemplar(
 	:binary_operator_definition,
 	{
-		{:operator, _unset, :readable, :public},
-		{:lhs_type_name, _unset, :readable, :public},
-		{:rhs_type_name, _unset, :readable, :public},
-		{:result_type_name, _unset, :readable, :public}
+		{:op, _unset, :readable, :public},
+		{:lhs_type_n, _unset, :readable, :public},
+		{:rhs_type_n, _unset, :readable, :public},
+		{:res_type_n, _unset, :readable, :public}
 	},
 	{@mt:definition})
+$
+
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+binary_operator_definition.define_shared_constant(
+	:instruction_type,
+	9,
+	:public)
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
@@ -38,10 +46,10 @@ _private _method binary_operator_definition.init(operator, lhs_type_name, rhs_ty
 	## @param {sw:char16_vector} rhs_type_name
 	## @param {sw:char16_vector} result_type_name
 	## @return {_self}
-	.operator << operator
-	.lhs_type_name << lhs_type_name
-	.rhs_type_name << rhs_type_name
-	.result_type_name << result_type_name
+	.op << operator
+	.lhs_type_n << lhs_type_name
+	.rhs_type_n << rhs_type_name
+	.res_type_n << result_type_name
 	_return _self
 _endmethod
 $
@@ -59,9 +67,9 @@ _method binary_operator_definition.equals?(other)
 	## Equals?
 	## @param {mt:binary_operator_definition} other
 	## @return {sw:false}
-	_return _self.operator = other.operator _andif
-		_self.lhs_type_name = other.lhs_type_name _andif
-		_self.rhs_type_name = other.rhs_type_name _andif
+	_return _self.op = other.op _andif
+		_self.lhs_type_n = other.lhs_type_n _andif
+		_self.rhs_type_n = other.rhs_type_n _andif
 		_self.return_type_name = other.return_type_name
 _endmethod
 $
@@ -71,9 +79,9 @@ _method binary_operator_definition.equals_disregarding_typing?(other)
 	## Equals disregarding typing?
 	## @param {mt:binary_operator_definition} other
 	## @return {sw:false}
-	_return _self.operator = other.operator _andif
-		_self.lhs_type_name = other.lhs_type_name _andif
-		_self.rhs_type_name = other.rhs_type_name
+	_return _self.op = other.op _andif
+		_self.lhs_type_n = other.lhs_type_n _andif
+		_self.rhs_type_n = other.rhs_type_n
 _endmethod
 $
 
@@ -92,13 +100,13 @@ define_binary_operator_case(
 	_proc(definition_a, definition_b)
 		## @param {mt:binary_operator_definition} definition_a
 		## @param {mt:binary_operator_definition} definition_b
-		## @return {sw:false}
+		## @return {sw:false|sw:maybe}
 		_return definition_a.equals?(definition_b)
 	_endproc)
 $
 
 binary_operator_definition.define_show_attributes(
-	:operator,
-	:lhs_type_name,
-	:rhs_type_name)
+	:op,
+	:lhs_type_n,
+	:rhs_type_n)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/condition_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/condition_definition.magik
@@ -4,44 +4,57 @@ _package mt
 _pragma(classify_level=basic, topic=type_dumper)
 ## Condition definition.
 ## @slot {sw:char16_vector} name
-## @slot {sw:simple_vector<E=sw:char16_vector>} data_names
-## @slot {sw:char16_vector|sw:unset} parent
+## @slot {sw:simple_vector<E=sw:char16_vector>} data_n
+## @slot {sw:char16_vector|sw:unset} par
 ## @slot {sw:char16_vector|sw:unset} doc
+## @slot {sw:char16_vector|sw:unset} src
 def_slotted_exemplar(
 	:condition_definition,
 	{
 		{:name, _unset, :readable, :public},
-		{:data_names, _unset, :readable, :public},
-		{:parent, _unset, :readable, :public},
-		{:doc, _unset, :readable, :public}
+		{:data_n, _unset, :readable, :public},
+		{:par, _unset, :readable, :public},
+		{:doc, _unset, :readable, :public},
+		{:src, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+condition_definition.define_shared_constant(
+	:instruction_type,
+	8,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
-_method condition_definition.new(name, data_names, parent, doc)
+_method condition_definition.new(name, data_names, parent, doc, source_file)
 	## Constructor.
 	## @param {sw:char16_vector} name
 	## @param {sw:simple_vector<E=sw:char16_vector>} data_names
 	## @param {sw:char16_vector|sw:unset} parent
 	## @param {sw:char16_vector|sw:unset} doc
+	## @param {sw:char16_vector|sw:unset} source_file
 	## @return {_self}
-	_return _clone.init(name, data_names, parent, doc)
+	_return _clone.init(name, data_names, parent, doc, source_file)
 _endmethod
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
-_private _method condition_definition.init(name, data_names, parent, doc)
+_private _method condition_definition.init(name, data_names, parent, doc, source_file)
 	## Initializer.
 	## @param {sw:char16_vector} name
 	## @param {sw:simple_vector<E=sw:char16_vector>} data_names
 	## @param {sw:char16_vector|sw:unset} parent
 	## @param {sw:char16_vector|sw:unset} doc
+	## @param {sw:char16_vector|sw:unset} source_file
 	## @return {_self}
 	.name << name
-	.data_names << data_names
-	.parent << parent
+	.data_n << data_names
+	.par << parent
 	.doc << doc
+	.src << source_file
 	_return _self
 _endmethod
 $
@@ -57,11 +70,18 @@ _method condition_definition.new_from(cond)
 			>> cond.taxonomy[cond.taxonomy.size - 1]
 		_endif
 	_local doc << method_finder.get_method_comment(cond.name, "<condition>")
+	_local source_file <<
+		_try
+			>> cond.source_file
+		_when error
+			>> _unset
+		_endtry
 	_return _self.new(
 		cond.name,
 		cond.data_name_list,
 		parent,
-		doc)
+		doc,
+		source_file)
 _endmethod
 $
 
@@ -79,8 +99,8 @@ _method condition_definition.equals?(other)
 	## @param {mt:condition_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.data_names.eq?(other.data_names) _andif
-		_self.parent = other.parent _andif
+		_self.data_n.eq?(other.data_n) _andif
+		_self.par = other.par _andif
 		_self.doc = other.doc
 _endmethod
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/definition.magik
@@ -49,6 +49,14 @@ definition.define_shared_constant(
 	:public)
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=subclassable)
+## @return {sw:integer}
+definition.define_shared_constant(
+	:instruction_type,
+	-1,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
 _method definition.new_from_json(instruction)
 	## Construct self from JSON.
@@ -69,7 +77,7 @@ _private _method definition.init_from_json(instruction)
 		_local value << instruction[fixed_name]
 		_local fixed_value <<
 			_if value.is_kind_of?(sw:simple_vector) _orif
-			    value.is_kind_of?(sw:rope)
+				value.is_kind_of?(sw:rope)
 			_then
 				>> value.as_simple_vector()
 			_else
@@ -94,9 +102,9 @@ _method definition.as_properties()
 	## Get slots as hash table.
 	## @return {sw:equality_property_list<K=sw:char16_vector, E=sw:object>}
 	_local fix_value <<
-		_proc(value)
+		_proc (value)
 			_if value.is_kind_of?(mt:definition) _orif
-			    value.is_kind_of?(mt:usage)
+				value.is_kind_of?(mt:usage)
 			_then
 				_return value.as_properties()
 			_endif
@@ -118,6 +126,13 @@ _method definition.as_properties()
 			_else
 				>> value
 			_endif
+
+		# for smaller file sizes = faster parsing
+		_if value _is _unset
+		_then
+			_continue
+		_endif
+
 		table[fixed_name] << fixed_value
 	_endloop
 	_return table
@@ -128,8 +143,12 @@ _pragma(classify_level=basic, topic=type_dumper)
 _method definition.generate_json_string()
 	## Generate a json string from self.
 	## @return {sw:char16_vector}
-	_local instruction << _self.as_properties()
-	instruction[:instruction] << _self.class_name.write_string.split_by(%_)[1]
+	_local properties << _self.as_properties()
+
+	# so that .i is at the front
+	_local instruction << sw:equality_property_list.new_with(:i, _self.instruction_type)
+	instruction.add_all(properties)
+
 	_local encoder << sw:json_encoder.new()
 	_return encoder.generate_string(instruction)
 _endmethod

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/global_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/global_definition.magik
@@ -3,15 +3,23 @@ _package mt
 
 _pragma(classify_level=basic, topic=type_dumper)
 ## Global definition.
-## @slot {sw:char16_vector} type_name
-## @slot {sw:char16_vector} aliased_type_name
+## @slot {sw:char16_vector} type_n
+## @slot {sw:char16_vector} alias_type_n
 def_slotted_exemplar(
 	:global_definition,
 	{
-		{:type_name, _unset, :readable, :public},
-		{:aliased_type_name, _unset, :readable, :public}
+		{:type_n, _unset, :readable, :public},
+		{:alias_type_n, _unset, :readable, :public}
 	},
 	{@mt:definition})
+$
+
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+global_definition.define_shared_constant(
+	:instruction_type,
+	5,
+	:public)
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
@@ -30,8 +38,8 @@ _private _method global_definition.init(type_name, aliased_type_name)
 	## @param {sw:char16_vector} type_name
 	## @param {sw:char16_vector} aliased_type_name
 	## @return {_self}
-	.type_name << type_name
-	.aliased_type_name << aliased_type_name
+	.type_n << type_name
+	.alias_type_n << aliased_type_name
 	_return _self
 _endmethod
 $
@@ -61,7 +69,7 @@ _pragma(condition_definition=basic, topic=type_dumper)
 _method global_definition.sort_value
 	## Sort value.
 	## @return {sw:char16_vector}
-	_return .type_name
+	_return .type_n
 _endmethod
 $
 
@@ -70,8 +78,8 @@ _method global_definition.equals?(other)
 	## Equals?
 	## @param {mt:global_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
-		_self.aliased_type_name = other.aliased_type_name
+	_return _self.type_n = other.type_n _andif
+		_self.alias_type_n = other.alias_type_n
 _endmethod
 $
 
@@ -80,7 +88,7 @@ _method global_definition.equals_disregarding_typing?(other)
 	## Equals disregarding typing?
 	## @param {mt:global_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name
+	_return _self.type_n = other.type_n
 _endmethod
 $
 
@@ -105,5 +113,5 @@ define_binary_operator_case(
 $
 
 global_definition.define_show_attributes(
-	:type_name)
+	:type_n)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/method_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/method_definition.magik
@@ -3,35 +3,43 @@ _package mt
 
 _pragma(classify_level=basic, topic=type_dumper)
 ## Method definition.
-## @slot {sw:char16_vector} type_name
-## @slot {sw:char16_vector} method_name
-## @slot {sw:simple_vector<E=sw:char16_vector>} modifiers
-## @slot {sw:simple_vector<E=mt:parameter_definition>} parameters
-## @slot {mt:parameter_definition|sw:unset} assignment_parameter
-## @slot {sw:simple_vector<E=sw:char16_vector>} return_types
-## @slot {sw:simple_vector<E=sw:char16_vector>} loop_types
-## @slot {sw:char16_vector|sw:unset} source_file
+## @slot {sw:char16_vector} type_n
+## @slot {sw:char16_vector} m_name
+## @slot {sw:simple_vector<E=sw:char16_vector>} mods
+## @slot {sw:simple_vector<E=mt:parameter_definition>} params
+## @slot {mt:parameter_definition|sw:unset} a_param
+## @slot {sw:simple_vector<E=sw:char16_vector>} ret
+## @slot {sw:simple_vector<E=sw:char16_vector>} loop
+## @slot {sw:char16_vector|sw:unset} src
 ## @slot {sw:char16_vector|sw:unset} doc
 ## @slot {sw:char16_vector|sw:unset} hash
-## @slot {sw:char16_vector|sw:unset} module_name
-## @slot {sw:simple_vector<E=sw:char16_vector>} topics
+## @slot {sw:char16_vector|sw:unset} mod_n
+## @slot {sw:simple_vector<E=sw:char16_vector>} top
 def_slotted_exemplar(
 	:method_definition,
 	{
-		{:type_name, _unset, :readable, :public},
-		{:method_name, _unset, :readable, :public},
-		{:modifiers, _unset, :readable, :public},
-		{:parameters, _unset, :readable, :public},
-		{:assignment_parameter, _unset, :readable, :public},
-		{:return_types, _unset, :readable, :public},
-		{:loop_types, _unset, :readable, :public},
-		{:source_file, _unset, :readable, :public},
+		{:type_n, _unset, :readable, :public},
+		{:m_name, _unset, :readable, :public},
+		{:mods, _unset, :readable, :public},
+		{:params, _unset, :readable, :public},
+		{:a_param, _unset, :readable, :public},
+		{:ret, _unset, :readable, :public},
+		{:loop, _unset, :readable, :public},
+		{:src, _unset, :readable, :public},
 		{:doc, _unset, :readable, :public},
 		{:hash, _unset, :readable, :public},
-		{:module_name, _unset, :readable, :public},
-		{:topics, _unset, :readable, :public}
+		{:mod_n, _unset, :readable, :public},
+		{:top, _unset, :readable, :public}
 	},
 	{@mt:definition})
+$
+
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+method_definition.define_shared_constant(
+	:instruction_type,
+	6,
+	:public)
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
@@ -106,18 +114,18 @@ _private _method method_definition.init(
 	## @param {sw:char16_vector|sw:unset} module_name
 	## @param {sw:simple_vector<E=sw:char16_vector>} topics
 	## @return {_self}
-	.type_name << type_name
-	.method_name << method_name
-	.modifiers << modifiers
-	.parameters << parameters
-	.assignment_parameter << assignment_parameter
-	.return_types << return_types
-	.loop_types << loop_types
-	.source_file << source_file
+	.type_n << type_name
+	.m_name << method_name
+	.mods << modifiers
+	.params << parameters
+	.a_param << assignment_parameter
+	.ret << return_types
+	.loop << loop_types
+	.src << source_file
 	.doc << doc
 	.hash << hash
-	.module_name << module_name
-	.topics << topics
+	.mod_n << module_name
+	.top << topics
 	_return _self
 _endmethod
 $
@@ -130,15 +138,15 @@ _private _method method_definition.init_from_json(instruction)
 	_super.init_from_json(instruction)
 
 	# Fix parameters.
-	.parameters << .parameters.map(
+	.params << .params.map(
 		_proc(param)
 			_return parameter_definition.sys!perform(:|new_from_json()|, param)
 		_endproc)
 
 	# Fix assignment_parameter.
-	_if .assignment_parameter _isnt _unset
+	_if .a_param _isnt _unset
 	_then
-		.assignment_parameter << parameter_definition.sys!perform(:|new_from_json()|, .assignment_parameter)
+		.a_param << parameter_definition.sys!perform(:|new_from_json()|, .a_param)
 	_endif
 
 	_return _self
@@ -215,7 +223,7 @@ _method method_definition.new_from(package, name, method)
 		_try
 			>> method.source_module.name
 		_when error
-			# pass
+			>> _unset
 		_endtry
 	_local topics <<
 		_try
@@ -243,7 +251,7 @@ _pragma(condition_definition=basic, topic=type_dumper)
 _method method_definition.sort_value
 	## Sort value.
 	## @return {sw:char16_vector}
-	_return .type_name + "." + .method_name
+	_return .type_n + "." + .m_name
 _endmethod
 $
 
@@ -252,18 +260,18 @@ _method method_definition.equals?(other)
 	## Equals?
 	## @param {mt:method_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
-		_self.method_name = other.method_name _andif
-		_self.modifiers.eq?(other.modifiers) _andif
-		_self.parameters.eq?(other.parameters) _andif
-		_self.assignment_parameter = other.assignment_parameter _andif
-		_self.return_types.eq?(other.return_types) _andif
-		_self.loop_types.eq?(other.loop_types) _andif
-		_self.source_file = other.source_file _andif
+	_return _self.type_n = other.type_n _andif
+		_self.m_name = other.m_name _andif
+		_self.mods.eq?(other.mods) _andif
+		_self.params.eq?(other.params) _andif
+		_self.a_param = other.a_param _andif
+		_self.ret.eq?(other.ret) _andif
+		_self.loop.eq?(other.loop) _andif
+		_self.src = other.src _andif
 		_self.doc = other.doc _andif
 		_self.hash = other.hash _andif
-		_self.module_name = other.module_name _andif
-		_self.topics.eq?(other.topics)
+		_self.mod_n = other.mod_n _andif
+		_self.top.eq?(other.top)
 _endmethod
 $
 
@@ -272,17 +280,17 @@ _method method_definition.equals_disregarding_typing?(other)
 	## Equals disregarding typing?
 	## @param {mt:method_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
-		_self.method_name = other.method_name _andif
-		_self.modifiers.eq?(other.modifiers) _andif
-		_self.parameters.eq?(other.parameters, :|equals_disregarding_typing?()|) _andif (
-			_self.assignment_parameter _is _unset _andif other.assignment_parameter _is _unset _orif
-			_self.assignment_parameter.equals_disregarding_typing?(other.assignment_parameter)) _andif
-		_self.source_file = other.source_file _andif
+	_return _self.type_n = other.type_n _andif
+		_self.m_name = other.m_name _andif
+		_self.mods.eq?(other.mods) _andif
+		_self.params.eq?(other.params, :|equals_disregarding_typing?()|) _andif (
+			_self.a_param _is _unset _andif other.a_param _is _unset _orif
+			_self.a_param.equals_disregarding_typing?(other.a_param)) _andif
+		_self.src = other.src _andif
 		_self.doc = other.doc _andif
 		_self.hash = other.hash _andif
-		_self.module_name = other.module_name _andif
-		_self.topics.eq?(other.topics)
+		_self.mod_n = other.mod_n _andif
+		_self.top.eq?(other.top)
 _endmethod
 $
 
@@ -307,6 +315,6 @@ define_binary_operator_case(
 $
 
 method_definition.define_show_attributes(
-	:type_name,
-	:method_name)
+	:type_n,
+	:m_name)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/module_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/module_definition.magik
@@ -4,47 +4,60 @@ _package mt
 _pragma(classify_level=basic, topic=type_dumper)
 ## Module definition.
 ## @slot {sw:char16_vector} name
-## @slot {sw:char16_vector|sw:unset} product
-## @slot {sw:char16_vector|sw:unset} base_version
-## @slot {sw:char16_vector|sw:unset} current_version
-## @slot {sw:simple_vector<E=mt:module_usage>} usages
+## @slot {sw:char16_vector|sw:unset} prod
+## @slot {sw:char16_vector|sw:unset} base_ver
+## @slot {sw:char16_vector|sw:unset} cur_ver
+## @slot {sw:simple_vector<E=mt:module_usage>} usgs
+## @slot {sw:char16_vector|sw:unset} src
 def_slotted_exemplar(
 	:module_definition,
 	{
 		{:name, _unset, :readable, :public},
-		{:product, _unset, :readable, :public},
-		{:base_version, _unset, :readable, :public},
-		{:current_version, _unset, :readable, :public},
-		{:usages, _unset, :readable, :public}
+		{:prod, _unset, :readable, :public},
+		{:base_ver, _unset, :readable, :public},
+		{:cur_ver, _unset, :readable, :public},
+		{:usgs, _unset, :readable, :public},
+		{:src, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+module_definition.define_shared_constant(
+	:instruction_type,
+	2,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
-_method module_definition.new(name, product, base_version, current_version, usages)
+_method module_definition.new(name, product, base_version, current_version, usages, source_module_def)
 	## Constructor.
 	## @param {sw:char16_vector} name
 	## @param {sw:char16_vector|sw:unset} product
 	## @param {sw:char16_vector|sw:unset} base_version
 	## @param {sw:char16_vector|sw:unset} current_version
 	## @param {sw:simple_vector<E=mt:module_usage>} usages
-	_return _clone.init(name, product, base_version, current_version, usages)
+	## @param {sw:char16_vector|sw:unset} source_module_def
+	_return _clone.init(name, product, base_version, current_version, usages, source_module_def)
 _endmethod
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
-_private _method module_definition.init(name, product, base_version, current_version, usages)
+_private _method module_definition.init(name, product, base_version, current_version, usages, source_module_def)
 	## Initializer.
 	## @param {sw:char16_vector} name
 	## @param {sw:char16_vector|sw:unset} product
 	## @param {sw:char16_vector|sw:unset} base_version
 	## @param {sw:char16_vector|sw:unset} current_version
 	## @param {sw:simple_vector<E=mt:module_usage>} usages
+	## @param {sw:char16_vector|sw:unset} source_module_def
 	.name << name
-	.product << product
-	.base_version << base_version
-	.current_version << current_version
-	.usages << usages
+	.prod << product
+	.base_ver << base_version
+	.cur_ver << current_version
+	.usgs << usages
+	.src << source_module_def
 	_return _self
 _endmethod
 $
@@ -54,6 +67,13 @@ _method module_definition.new_from(module)
 	## Construct self from `sw:sw_module`.
 	## @param {sw:sw_module} module
 	## @return {_self}
+	_local source_module_def <<
+		_try
+			>> system.pathname_down(module.full_directory, "module.def")
+		_when error
+			>> _unset
+		_endtry
+
 	_return _self.new(
 		module.name,
 		module.product.name,
@@ -63,7 +83,8 @@ _method module_definition.new_from(module)
 			map(_proc(prereq) _return prereq[1] _endproc).
 			as_sorted_collection().
 			as_simple_vector().
-			map(_proc(prereq) _return module_usage.new(prereq) _endproc))
+			map(_proc(prereq) _return module_usage.new(prereq) _endproc),
+		source_module_def)
 _endmethod
 $
 
@@ -81,10 +102,10 @@ _method module_definition.equals?(other)
 	## @param {mt:module_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.product = other.product _andif
-		_self.base_version = other.base_version _andif
-		_self.current_version = other.current_version _andif
-		_self.usages.eq?(other.usages)
+		_self.prod = other.prod _andif
+		_self.base_ver = other.base_ver _andif
+		_self.cur_ver = other.cur_ver _andif
+		_self.usgs.eq?(other.usgs)
 _endmethod
 $
 
@@ -119,5 +140,5 @@ $
 
 module_definition.define_show_attributes(
 	:name,
-	:product)
+	:prod)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/package_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/package_definition.magik
@@ -14,6 +14,14 @@ def_slotted_exemplar(
 	{@mt:definition})
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+package_definition.define_shared_constant(
+	:instruction_type,
+	3,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
 _method package_definition.new(name, uses)
 	## Constructor.

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/parameter_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/parameter_definition.magik
@@ -4,14 +4,14 @@ _package mt
 _pragma(classify_level=basic, topic=type_dumper)
 ## Parameter definition.
 ## @slot {sw:char16_vector} name
-## @slot {sw:char16_vector} modifier
-## @slot {sw:char16_vector} type_name
+## @slot {sw:char16_vector} mod
+## @slot {sw:char16_vector} type_n
 def_slotted_exemplar(
 	:parameter_definition,
 	{
 		{:name, _unset, :readable, :public},
-		{:modifier, _unset, :readable, :public},
-		{:type_name, _unset, :readable, :public}
+		{:mod, _unset, :readable, :public},
+		{:type_n, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
@@ -35,8 +35,8 @@ _private _method parameter_definition.init(name, modifier, type_name)
 	## @param {sw:char16_vector} type_name
 	## @return {_self}
 	.name << name
-	.modifier << modifier
-	.type_name << type_name
+	.mod << modifier
+	.type_n << type_name
 	_return _self
 _endmethod
 $
@@ -80,12 +80,25 @@ _method parameter_definition.new_from(name, procedure)
 	_endif
 
 	_local parameter_definitions << sw:rope.new()
-	_local param_list << procedure.basic_arglist
+	_local param_list <<
+		_if procedure.responds_to?(:basic_arglist)
+		_then
+			_local arglist << {}
+			_try
+				arglist << procedure.basic_arglist
+			_when error
+				arglist << {}
+			_endtry
+			>> arglist
+		_else
+			>> {}
+		_endif
+
 	_for index, param_name _over param_list.fast_keys_and_elements()
 	_loop
 		_local modifier <<
 			_if procedure.gather_arg? _andif
-			    index = param_list.size
+				index = param_list.size
 			_then
 				>> "gather"
 			_elif index > procedure.num_mandatory_args
@@ -95,9 +108,9 @@ _method parameter_definition.new_from(name, procedure)
 				>> "none"
 			_endif
 		_local definition << _self.new(
-			param_name,
-			modifier,
-			_self.undefined_type)
+				param_name,
+				modifier,
+				_self.undefined_type)
 		parameter_definitions.add_last(definition)
 	_endloop
 
@@ -111,8 +124,8 @@ _method parameter_definition.equals?(other)
 	## @param {mt:parameter_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.modifier = other.modifier _andif
-		_self.type_name = other.type_name
+		_self.mod = other.mod _andif
+		_self.type_n = other.type_n
 _endmethod
 $
 
@@ -122,13 +135,13 @@ _method parameter_definition.equals_disregarding_typing?(other)
 	## @param {mt:parameter_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.modifier = other.modifier
+		_self.mod = other.mod
 _endmethod
 $
 
 define_binary_operator_case(
 	:|=|, parameter_definition, parameter_definition,
-	_proc(definition_a, definition_b)
+	_proc (definition_a, definition_b)
 		## @param {mt:parameter_definition} definition_a
 		## @param {mt:parameter_definition} definition_b
 		## @return {sw:false|sw:maybe}

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/procedure_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/procedure_definition.magik
@@ -3,29 +3,37 @@ _package mt
 
 _pragma(classify_level=basic, topic=type_dumper)
 ## Procedure definition.
-## @slot {sw:char16_vector} type_name
-## @slot {sw:char16_vector} procedure_name
-## @slot {sw:simple_vector<E=sw:char16_vector>} modifiers
-## @slot {sw:simple_vector<E=mt:parameter_definition>} parameters
-## @slot {sw:simple_vector<E=sw:char16_vector>} return_types
-## @slot {sw:simple_vector<E=sw:char16_vector>} loop_types
-## @slot {sw:char16_vector|sw:unset} source_file
+## @slot {sw:char16_vector} type_n
+## @slot {sw:char16_vector} proc_name
+## @slot {sw:simple_vector<E=sw:char16_vector>} mods
+## @slot {sw:simple_vector<E=mt:parameter_definition>} params
+## @slot {sw:simple_vector<E=sw:char16_vector>} ret
+## @slot {sw:simple_vector<E=sw:char16_vector>} loop
+## @slot {sw:char16_vector|sw:unset} src
 ## @slot {sw:char16_vector|sw:unset} doc
-## @slot {sw:char16_vector|sw:unset} module_name
+## @slot {sw:char16_vector|sw:unset} mod_n
 def_slotted_exemplar(
 	:procedure_definition,
 	{
-		{:type_name, _unset, :readable, :public},
-		{:procedure_name, _unset, :readable, :public},
-		{:modifiers, _unset, :readable, :public},
-		{:parameters, _unset, :readable, :public},
-		{:return_types, _unset, :readable, :public},
-		{:loop_types, _unset, :readable, :public},
-		{:source_file, _unset, :readable, :public},
+		{:type_n, _unset, :readable, :public},
+		{:proc_name, _unset, :readable, :public},
+		{:mods, _unset, :readable, :public},
+		{:params, _unset, :readable, :public},
+		{:ret, _unset, :readable, :public},
+		{:loop, _unset, :readable, :public},
+		{:src, _unset, :readable, :public},
 		{:doc, _unset, :readable, :public},
-		{:module_name, _unset, :readable, :public}
+		{:mod_n, _unset, :readable, :public}
 	},
 	{@mt:definition})
+$
+
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+procedure_definition.define_shared_constant(
+	:instruction_type,
+	7,
+	:public)
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
@@ -85,15 +93,15 @@ _private _method procedure_definition.init(
 	## @param {sw:char16_vector|sw:unset} doc
 	## @param {sw:char16_vector|sw:unset} module_name
 	## @return {_self}
-	.type_name << type_name
-	.procedure_name << procedure_name
-	.modifiers << modifiers
-	.parameters << parameters
-	.return_types << return_types
-	.loop_types << loop_types
-	.source_file << source_file
+	.type_n << type_name
+	.proc_name << procedure_name
+	.mods << modifiers
+	.params << parameters
+	.ret << return_types
+	.loop << loop_types
+	.src << source_file
 	.doc << doc
-	.module_name << module_name
+	.mod_n << module_name
 	_return _self
 _endmethod
 $
@@ -106,7 +114,7 @@ _private _method procedure_definition.init_from_json(instruction)
 	_super.init_from_json(instruction)
 
 	# Fix parameters.
-	.parameters << .parameters.map(
+	.params << .params.map(
 		_proc(param)
 			_return parameter_definition.sys!perform(:|new_from_json()|, param)
 		_endproc)
@@ -165,7 +173,7 @@ _pragma(condition_definition=basic, topic=type_dumper)
 _method procedure_definition.sort_value
 	## Sort value.
 	## @return {sw:char16_vector}
-	_return .type_name
+	_return .type_n
 _endmethod
 $
 
@@ -174,15 +182,15 @@ _method procedure_definition.equals?(other)
 	## Equals?
 	## @param {mt:procedure_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
-		_self.procedure_name = other.procedure_name _andif
-		_self.modifiers.eq?(other.modifiers) _andif
-		_self.parameters.eq?(other.parameters) _andif
-		_self.return_types.eq?(other.return_types) _andif
-		_self.loop_types.eq?(other.loop_types) _andif
-		_self.source_file = other.source_file _andif
+	_return _self.type_n = other.type_n _andif
+		_self.proc_name = other.proc_name _andif
+		_self.mods.eq?(other.mods) _andif
+		_self.params.eq?(other.params) _andif
+		_self.ret.eq?(other.ret) _andif
+		_self.loop.eq?(other.loop) _andif
+		_self.src = other.src _andif
 		_self.doc = other.doc _andif
-		_self.module_name = other.module_name
+		_self.mod_n = other.mod_n
 _endmethod
 $
 
@@ -191,13 +199,13 @@ _method procedure_definition.equals_disregarding_typing?(other)
 	## Equals disregarding typing?
 	## @param {mt:procedure_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
-		_self.procedure_name = other.procedure_name _andif
-		_self.modifiers.eq?(other.modifiers) _andif
-		_self.parameters.eq?(other.parameters, :|equals_disregarding_typing?()|) _andif
-		_self.source_file = other.source_file _andif
+	_return _self.type_n = other.type_n _andif
+		_self.proc_name = other.proc_name _andif
+		_self.mods.eq?(other.mods) _andif
+		_self.params.eq?(other.params, :|equals_disregarding_typing?()|) _andif
+		_self.src = other.src _andif
 		_self.doc = other.doc _andif
-		_self.module_name = other.module_name
+		_self.mod_n = other.mod_n
 _endmethod
 $
 
@@ -222,6 +230,6 @@ define_binary_operator_case(
 $
 
 procedure_definition.define_show_attributes(
-	:type_name,
-	:procedure_name)
+	:type_n,
+	:proc_name)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/product_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/product_definition.magik
@@ -4,49 +4,62 @@ _package mt
 _pragma(classify_level=basic, topic=type_dumper)
 ## Product definition.
 ## @slot {sw:char16_vector} name
-## @slot {sw:char16_vector|sw:unset} version
-## @slot {sw:char16_vector|sw:unset} version_comment
+## @slot {sw:char16_vector|sw:unset} ver
+## @slot {sw:char16_vector|sw:unset} ver_com
 ## @slot {sw:char16_vector|sw:unset} parent
-## @slot {sw:simple_vector<E=mt:product_usage>} usages
+## @slot {sw:simple_vector<E=mt:product_usage>} usgs
+## @slot {sw:char16_vector|sw:unset} src
 def_slotted_exemplar(
 	:product_definition,
 	{
 		{:name, _unset, :readable, :public},
-		{:version, _unset, :readable, :public},
-		{:version_comment, _unset, :readable, :public},
+		{:ver, _unset, :readable, :public},
+		{:ver_com, _unset, :readable, :public},
 		{:parent, _unset, :readable, :public},
-		{:usages, _unset, :readable, :public}
+		{:usgs, _unset, :readable, :public},
+		{:src, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+product_definition.define_shared_constant(
+	:instruction_type,
+	1,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
-_method product_definition.new(name, version, version_comment, parent, usages)
+_method product_definition.new(name, version, version_comment, parent, usages, source_product_def)
 	## Constructor.
 	## @param {sw:char16_vector} name
 	## @param {sw:char16_vector|sw:unset} version
 	## @param {sw:char16_vector|sw:unset} version_comment
 	## @param {sw:char16_vector|sw:unset} parent
 	## @param {sw:simple_vector<E=mt:product_usage>} usages
+	## @param {sw:char16_vector|sw:unset} source_product_def
 	## @return {_self}
-	_return _clone.init(name, version, version_comment, parent, usages)
+	_return _clone.init(name, version, version_comment, parent, usages, source_product_def)
 _endmethod
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
-_private _method product_definition.init(name, version, version_comment, parent, usages)
+_private _method product_definition.init(name, version, version_comment, parent, usages, source_product_def)
 	## Initializer.
 	## @param {sw:char16_vector} name
 	## @param {sw:char16_vector|sw:unset} version
 	## @param {sw:char16_vector|sw:unset} version_comment
 	## @param {sw:char16_vector|sw:unset} parent
 	## @param {sw:simple_vector<E=mt:product_usage>} usages
+	## @param {sw:char16_vector|sw:unset} source_product_def
 	## @return {_self}
 	.name << name
-	.version << version
-	.version_comment << version_comment
+	.ver << version
+	.ver_com << version_comment
 	.parent << parent
-	.usages << usages
+	.usgs << usages
+	.src << source_product_def
 	_return _self
 _endmethod
 $
@@ -61,17 +74,26 @@ _method product_definition.new_from(product)
 		_then
 			>> product.parent.name
 		_endif
+
 	_local usages << product.prerequisites.
 		map(_proc(prereq) _return prereq[1] _endproc).
 		as_sorted_collection().
 		as_simple_vector().
 		map(_proc(prereq) _return product_usage.new(prereq) _endproc)
+	_local source_product_def <<
+		_try
+			>> system.pathname_down(product.directory, "product.def")
+		_when error
+			>> _unset
+		_endtry
+
 	_return _self.new(
 		product.name,
 		product.version_string,
 		product.version.comment,
 		parent,
-		usages)
+		usages,
+		source_product_def)
 _endmethod
 $
 
@@ -89,10 +111,10 @@ _method product_definition.equals?(other)
 	## @param {mt:product_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.version = other.version _andif
-		_self.version_comment = other.version_comment _andif
+		_self.ver = other.ver _andif
+		_self.ver_com = other.ver_com _andif
 		_self.parent = other.parent _andif
-		_self.usages.eq?(other.usages)
+		_self.usgs.eq?(other.usgs)
 _endmethod
 $
 

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/slot_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/slot_definition.magik
@@ -4,12 +4,12 @@ _package mt
 _pragma(classify_level=basic, topic=type_dumper)
 ## Slot definition.
 ## @slot {sw:char16_vector} name
-## @slot {sw:char16_vector} type_name
+## @slot {sw:char16_vector} type_n
 def_slotted_exemplar(
 	:slot_definition,
 	{
 		{:name, _unset, :readable, :public},
-		{:type_name, _unset, :readable, :public}
+		{:type_n, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
@@ -31,7 +31,7 @@ _private _method slot_definition.init(name, type_name)
 	## @param {sw:char16_vector} type_name
 	## @return {_self}
 	.name << name
-	.type_name << type_name
+	.type_n << type_name
 	_return _self
 _endmethod
 $
@@ -52,7 +52,7 @@ _method slot_definition.equals?(other)
 	## @param {mt:slot_definition} other
 	## @return {sw:false}
 	_return _self.name = other.name _andif
-		_self.type_name = other.type_name
+		_self.type_n = other.type_n
 _endmethod
 $
 

--- a/sw_type_dumper/modules/sw_type_dumper/source/definitions/type_definition.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/definitions/type_definition.magik
@@ -3,29 +3,39 @@ _package mt
 
 _pragma(classify_level=basic, topic=type_dumper)
 ## Type definition.
-## @slot {sw:char16_vector} type_name
+## @slot {sw:char16_vector} type_n
 ## @slot {sw:char16_vector} sort
 ## @slot {sw:char16_vector|sw:unset} doc
-## @slot {sw:simple_vector<E=sw:char16_vector>} parents
+## @slot {sw:simple_vector<E=sw:char16_vector>} par
 ## @slot {sw:simple_vector<E=mt:slot_definition>} slots
-## @slot {sw:simple_vector<E=sw:char16_vector>} topics
-## @slot {sw:char16_vector|sw:unset} module_name
+## @slot {sw:simple_vector<E=sw:char16_vector>} top
+## @slot {sw:char16_vector|sw:unset} mod_n
+## @slot {sw:char16_vector|sw:unset} src
 def_slotted_exemplar(
 	:type_definition,
 	{
-		{:type_name, _unset, :readable, :public},
+		{:type_n, _unset, :readable, :public},
 		{:sort, _unset, :readable, :public},
 		{:doc, _unset, :readable, :public},
-		{:parents, _unset, :readable, :public},
+		{:par, _unset, :readable, :public},
 		{:slots, _unset, :readable, :public},
-		{:topics, _unset, :readable, :public},
-		{:module_name, _unset, :readable, :public}
+		{:top, _unset, :readable, :public},
+		{:mod_n, _unset, :readable, :public},
+		{:src, _unset, :readable, :public}
 	},
 	{@mt:definition})
 $
 
+_pragma(classify_level=basic, topic=type_dumper, usage=external)
+## @return {sw:integer}
+type_definition.define_shared_constant(
+	:instruction_type,
+	4,
+	:public)
+$
+
 _pragma(classify_level=basic, topic=type_dumper)
-_method type_definition.new(type_name, sort, doc, parents, slots, topics, module_name)
+_method type_definition.new(type_name, sort, doc, parents, slots, topics, module_name, src)
 	## Constructor.
 	## @param {sw:char16_vector} type_name
 	## @param {sw:char16_vector} sort
@@ -34,12 +44,13 @@ _method type_definition.new(type_name, sort, doc, parents, slots, topics, module
 	## @param {sw:simple_vector<E=mt:slot_definition>} slots
 	## @param {sw:simple_vector<E=sw:char16_vector>} topics
 	## @param {sw:char16_vector|sw:unset} module_name
-	_return _clone.init(type_name, sort, doc, parents, slots, topics, module_name)
+	## @param {sw:char16_vector|sw:unset} src
+	_return _clone.init(type_name, sort, doc, parents, slots, topics, module_name, src)
 _endmethod
 $
 
 _pragma(classify_level=basic, topic=type_dumper)
-_private _method type_definition.init(type_name, sort, doc, parents, slots, topics, module_name)
+_private _method type_definition.init(type_name, sort, doc, parents, slots, topics, module_name, src)
 	## Initializer.
 	## @param {sw:char16_vector} type_name
 	## @param {sw:char16_vector} sort
@@ -48,13 +59,15 @@ _private _method type_definition.init(type_name, sort, doc, parents, slots, topi
 	## @param {sw:simple_vector<E=mt:slot_definition>} slots
 	## @param {sw:simple_vector<E=sw:char16_vector>} topics
 	## @param {sw:char16_vector|sw:unset} module_name
-	.type_name << type_name
+	## @param {sw:char16_vector|sw:unset} src
+	.type_n << type_name
 	.sort << sort
 	.doc << doc
-	.parents << parents
+	.par << parents
 	.slots << slots
-	.topics << topics
-	.module_name << module_name
+	.top << topics
+	.mod_n << module_name
+	.src << src
 	_return _self
 _endmethod
 $
@@ -68,9 +81,9 @@ _private _method type_definition.init_from_json(instruction)
 
 	# Fix slots.
 	.slots << .slots.map(
-		_proc(slot)
-			_return slot_definition.sys!perform(:|new_from_json()|, slot)
-		_endproc)
+			_proc (slot)
+				_return slot_definition.sys!perform(:|new_from_json()|, slot)
+			_endproc)
 
 	_return _self
 _endmethod
@@ -109,6 +122,21 @@ _method type_definition.new_from(package, name, method_table)
 		_local source_type_name << _self.name_from_type(source_global_var.package, source_global_var.key)
 		parents.add_last(source_type_name)
 	_endloop
+	_local module_name << _if metadata[:exemplar] _isnt _unset
+		_then
+			>> _try
+				>> metadata[:exemplar].module_name
+			_when error
+				>> _unset
+			_endtry
+		_endif
+	_local src <<
+		_try
+			>> method_table.source_file
+		_when error
+			>> _unset
+		_endtry
+
 	_return _self.new(
 		type_name,
 		sort,
@@ -116,10 +144,8 @@ _method type_definition.new_from(package, name, method_table)
 		parents,
 		_self.build_slot_definitions(method_table),
 		method_finder.get_class_topics(type_name),
-		_if metadata[:exemplar] _isnt _unset
-		_then
-			>> metadata[:exemplar].module_name
-		_endif)
+		module_name,
+		src)
 _endmethod
 $
 
@@ -151,7 +177,7 @@ _pragma(condition_definition=basic, topic=type_dumper)
 _method type_definition.sort_value
 	## Sort value.
 	## @return {sw:char16_vector}
-	_return .type_name
+	_return .type_n
 _endmethod
 $
 
@@ -160,13 +186,13 @@ _method type_definition.equals?(other)
 	## Equals?
 	## @param {mt:type_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
+	_return _self.type_n = other.type_n _andif
 		_self.sort = other.sort _andif
 		_self.doc = other.doc _andif
-		_self.parents.eq?(other.parents) _andif
+		_self.par.eq?(other.par) _andif
 		_self.slots.eq?(other.slots) _andif
-		_self.topics.eq?(other.topics) _andif
-		_self.module_name = other.module_name
+		_self.top.eq?(other.top) _andif
+		_self.mod_n = other.mod_n
 _endmethod
 $
 
@@ -175,19 +201,19 @@ _method type_definition.equals_disregarding_typing?(other)
 	## Equals disregarding typing?
 	## @param {mt:type_definition} other
 	## @return {sw:false}
-	_return _self.type_name = other.type_name _andif
+	_return _self.type_n = other.type_n _andif
 		_self.sort = other.sort _andif
 		_self.doc = other.doc _andif
-		_self.parents.eq?(other.parents) _andif
+		_self.par.eq?(other.par) _andif
 		_self.slots.eq?(other.slots, :|equals_disregarding_typing?()|) _andif
-		_self.topics.eq?(other.topics) _andif
-		_self.module_name = other.module_name
+		_self.top.eq?(other.top) _andif
+		_self.mod_n = other.mod_n
 _endmethod
 $
 
 define_binary_operator_case(
 	:|cf|, type_definition, type_definition,
-	_proc(definition_a, definition_b)
+	_proc (definition_a, definition_b)
 		## @param {mt:type_definition} definition_a
 		## @param {mt:type_definition} definition_b
 		## @return {sw:false|sw:maybe}
@@ -197,7 +223,7 @@ $
 
 define_binary_operator_case(
 	:|=|, type_definition, type_definition,
-	_proc(definition_a, definition_b)
+	_proc (definition_a, definition_b)
 		## @param {mt:type_definition} definition_a
 		## @param {mt:type_definition} definition_b
 		## @return {sw:false|sw:maybe}
@@ -206,5 +232,5 @@ define_binary_operator_case(
 $
 
 type_definition.define_show_attributes(
-	:type_name)
+	:type_n)
 $

--- a/sw_type_dumper/modules/sw_type_dumper/source/type_dumper.magik
+++ b/sw_type_dumper/modules/sw_type_dumper/source/type_dumper.magik
@@ -19,11 +19,15 @@ _pragma(classify_level=basic, topic=type_dumper)
 ## Type dumper.
 ## @slot {sw:set} ignore_vars
 ## @slot {sw:external_text_output_stream} out_stream
+## @slot {sw:char16_vector} filename
+## @slot {sw:true|sw:false} write_done
 def_slotted_exemplar(
 	:type_dumper,
 	{
 		{:ignore_vars, _unset},
-		{:out_stream, _unset}
+		{:out_stream, _unset},
+		{:filename, _unset},
+		{:write_done, _false, :writable, :public}
 	})
 $
 
@@ -46,6 +50,7 @@ _private _method type_dumper.init(filename, _optional ignore_vars)
 	.ignore_vars << set.new_from(ignore_vars.default({}))
 	.ignore_vars.add(:|user:| + _self.class_name)
 	.out_stream << external_text_output_stream.new(filename)
+	.filename << filename
 	_return _self
 _endmethod
 $
@@ -77,10 +82,33 @@ _endmethod
 $
 
 _pragma(classify_level=basic, topic=type_dumper, usage=external)
-_method type_dumper.run()
+_method type_dumper.run(_optional debug?)
 	## Run the dump.
+	## @param {sw:false} debug? turn on debug output
+	##
+
+	debug? << debug?.default(_false)
 	_protect
+	_if debug?
+		_then
+			write("Starting type dumper: ", date_time.now());
+		_endif
+
 		_self.int!run()
+
+		_if debug?
+		_then
+			write("Type dumper finished: ", date_time.now());
+		_endif
+
+		_if .write_done _isnt _false
+		_then
+			_local done_stream <<
+				external_text_output_stream.new(write_string(.filename, ".done"))
+
+			done_stream.write("done")
+			done_stream.close()
+		_endif
 	_protection
 		_self.deinit()
 	_endprotect
@@ -105,6 +133,11 @@ _private _method type_dumper.int!run()
 	_local sorted_products << sorted_collection.new_from(smallworld_product.products, {:method_result, :name})
 	_for product _over sorted_products.fast_elements()
 	_loop
+		_if .ignore_vars.includes?(product.name)
+		_then
+			_continue
+		_endif
+
 		_local def << product_definition.new_from(product)
 		_self.write_definition(def)
 	_endloop
@@ -114,6 +147,11 @@ _private _method type_dumper.int!run()
 	_local sorted_modules << sorted_collection.new_from(sw_module_manager.defined_modules, {:method_result, :name})
 	_for module _over sorted_modules.fast_elements()
 	_loop
+		_if .ignore_vars.includes?(module.name)
+		_then
+			_continue
+		_endif
+
 		_local def << module_definition.new_from(module)
 		_self.write_definition(def)
 	_endloop
@@ -123,6 +161,11 @@ _private _method type_dumper.int!run()
 	_local sorted_pkgs << sorted_collection.new_from(package.all_packages, {:method_result, :name})
 	_for pkg _over sorted_pkgs.fast_elements()
 	_loop
+		_if .ignore_vars.includes?(pkg.name)
+		_then
+			_continue
+		_endif
+
 		_local def << package_definition.new_from(pkg)
 		_self.write_definition(def)
 	_endloop

--- a/sw_type_dumper/scripts/dump_types.magik
+++ b/sw_type_dumper/scripts/dump_types.magik
@@ -3,7 +3,7 @@
 _block
 	_local product_dir << system.pathname_up(!source_file!, 2)
 	smallworld_product.add_product(product_dir)
-	sw_module_manager.load_module(:sw_type_dumper)
+	sw_module_manager.load_module(:sw_type_dumper, _unset, :force_reload?, _true)
 _endblock
 $
 
@@ -19,6 +19,7 @@ _block
 	write_with_spaces(date_time.now(), "Start writing to:", filepath)
 
 	_local ignore_vars << set.new_with(
+		:|mt|,
 		:|mt:binary_operator_definition|,
 		:|mt:condition_definition|,
 		:|mt:datamodel_type_dumper|,
@@ -36,7 +37,8 @@ _block
 		:|mt:type_definition|,
 		:|mt:type_dumper|,
 		:|mt:type_merger|,
-		:|mt:usage|)
+		:|mt:usage|,
+		:|sw_type_dumper|)
 	_local dumper << mt:type_dumper.new(filepath, ignore_vars)
 	dumper.run()
 


### PR DESCRIPTION
Hi Steven,

this is one of the bigger pull requests where I am trying to merge all my improvements into your project. (Hopefully you think of them as improvements too ^^)

This pull request should be merged after #200 since I branched away from there on purpose.

I "rewrote" the facilities around JSON definitions so that they are

1. faster to parse and
2. smaller in file size

since I pretty quickly ran into this problem after adding path mappings (for finding compiled code while indexing.)

## Changes

Most of the new added files are just the custom (de-)serializers for all definitions

- refactor JsonDefinitionReader/-Writer to only use custom (de-)serializers
  - parallelization when reading a line
  - use smaller schema/properties for smaller file sizes
  - this is all so that type databases can be read faster and require less disk space
- added `PathMapping` class for the reading of definitions
- added `Computable` interface and `Memoizer` for caching longer running methods in parallel
- added additional `Location.validLocation` method with path mapping argument
- added converting arrays of non-primitive types to `JsonObjectPropertiesConverter` (for `PathMapping`)
- added following settings:
  - `magik.smallworldGis` -> path to the Smallworld GIS Core directory
  - `magik.pathMapping` -> array of path mapppings to use when converting `Location` paths
- change `MagikWorkspaceService` to only read type db files ending in .v2.jsonl (since I changed the JSON schema)
- change tests to match the shorter properties
- refactor `sw_type_dumper` to generate definitions with shorter properties and some additional information