### PR TITLE
Small improvements for debugging experience

### DIFF
--- a/magik-debug-adapter/README.md
+++ b/magik-debug-adapter/README.md
@@ -14,7 +14,9 @@ The following functionality is provided:
 
 ## Smallworld Magik Debugger Adapter in session
 
-Before this Debug Adapter can connect to your Smallworld session, the Smallworld session needs to be started with the Magik Debugger Agent (mda). This can be done by starting the JVM running the Smallworld session with the parameter `-agentpath:<path_to_Smallworld_core>/bin/Linux.x86/libmda.so=socket` (in case you're running on Windows, the mda is named libmda.dll, most likely). The mda communicates via a TCP/IP socket. The port can be provided with the settings `port=...`.
+Before this Debug Adapter can connect to your Smallworld session, the Smallworld session needs to be started with the Magik Debugger Agent (mda).
+This can be done by starting the JVM running the Smallworld session with the parameter `-agentpath:<path_to_Smallworld_core>/bin/Linux.x86/libmda.so=socket`
+(in case you're running on Windows, the mda is named mda.dll). The mda communicates via a TCP/IP socket. The port can be provided with the settings `port=...`.
 
 A complete example of running a session from `runalias` on Linux, specifying port `32000`, is as follows:
 
@@ -25,6 +27,15 @@ Sourcing ...
 ```
 
 Note that the default port the mda uses is `20000`.
+
+On Windows it would look like this:
+
+```batch
+C:\> <path-to-core>\bin\x86\runalias.exe -e /path/to/env -j -agentpath:<path-to-core>\bin\x86\mda.dll=socket,port=32000 swaf
+```
+
+The default port for Windows seems to be `32000` and the .dll does not care what port you specify.
+
 
 ## Configuration
 

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/MagikDebugAdapter.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/MagikDebugAdapter.java
@@ -228,7 +228,6 @@ public class MagikDebugAdapter implements IDebugProtocolServer, SlapEventListene
           this.threadManager = null;
           this.variableManager = null;
           this.breakpointManager = null;
-          System.exit(1);
         });
   }
 

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/MagikDebugAdapter.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/MagikDebugAdapter.java
@@ -228,6 +228,7 @@ public class MagikDebugAdapter implements IDebugProtocolServer, SlapEventListene
           this.threadManager = null;
           this.variableManager = null;
           this.breakpointManager = null;
+          System.exit(1);
         });
   }
 

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
@@ -7,6 +7,7 @@ import java.net.SocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.LogManager;
 import org.apache.commons.cli.CommandLine;
@@ -106,7 +107,7 @@ public final class Main {
       launcher = DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
     }
 
-    assert launcher != null;
+    Objects.requireNonNull(launcher, "Could not create debug adapter launcher");
     final IDebugProtocolClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
@@ -2,13 +2,14 @@ package nl.ramsolutions.sw.magik.debugadapter;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -19,10 +20,19 @@ public final class Main {
   private static final Options OPTIONS;
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
+  private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
+      Option.builder()
+          .longOpt("net")
+          .desc("Open the debug adapter on port 5008 instead of STDIN")
+          .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
+    OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -79,12 +89,35 @@ public final class Main {
     }
 
     final MagikDebugAdapter server = new MagikDebugAdapter();
-    final Launcher<IDebugProtocolClient> launcher =
-        DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<IDebugProtocolClient> launcher;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher = createSocketLauncher(server, new InetSocketAddress("localhost", 5008));
+    } else {
+      launcher = DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    }
 
+    assert launcher != null;
     final IDebugProtocolClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<IDebugProtocolClient> createSocketLauncher(
+      MagikDebugAdapter debugAdapter, SocketAddress socketAddress) throws IOException {
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return DSPLauncher.createServerLauncher(
+            debugAdapter,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel));
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
+    return null;
   }
 }

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/Main.java
@@ -9,7 +9,12 @@ import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -25,7 +30,11 @@ public final class Main {
   private static final Option OPTION_NET =
       Option.builder()
           .longOpt("net")
-          .desc("Open the debug adapter on port 5008 instead of STDIN")
+          .desc("Open the LSP on a port instead of using STDIN for commands (default: 5008)")
+          .hasArg()
+          .optionalArg(true)
+          .type(Integer.class)
+          .argName("PORT")
           .build();
 
   static {
@@ -91,7 +100,8 @@ public final class Main {
     final MagikDebugAdapter server = new MagikDebugAdapter();
     Launcher<IDebugProtocolClient> launcher;
     if (commandLine.hasOption(OPTION_NET)) {
-      launcher = createSocketLauncher(server, new InetSocketAddress("localhost", 5008));
+      int port = commandLine.getParsedOptionValue(OPTION_NET, 5008);
+      launcher = createSocketLauncher(server, new InetSocketAddress("localhost", port));
     } else {
       launcher = DSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
     }

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/ThreadManager.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/ThreadManager.java
@@ -164,7 +164,10 @@ class ThreadManager {
           LOGGER.debug("Eval expression: '{}'", expr);
           final EvalResponse eval =
               (EvalResponse) this.slapProtocol.evaluate(threadId, level, expr).get();
-          method = eval.getResult() + ":" + method;
+          final String result = eval.getResult();
+          if (!result.contains("does_not_understand")) {
+            method = eval.getResult() + ":" + method;
+          }
 
           // Bonus: update exemplar name with package.
           stackElement.setName(method);

--- a/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/slap/RequestType.java
+++ b/magik-debug-adapter/src/main/java/nl/ramsolutions/sw/magik/debugadapter/slap/RequestType.java
@@ -15,7 +15,7 @@ public enum RequestType {
   SOURCE_FILE(9),
   STEP(10),
 
-  UNKOWN(255);
+  UNKNOWN(255);
 
   private final int val;
 
@@ -28,7 +28,7 @@ public enum RequestType {
   }
 
   /**
-   * Get the {@link RequestType} from an interger value.
+   * Get the {@link RequestType} from an integer value.
    *
    * @param value Integer value.
    * @return RequestType

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageClient.java
@@ -1,0 +1,7 @@
+package nl.ramsolutions.sw.magik.languageserver;
+
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public interface MagikLanguageClient extends LanguageClient {
+  // For future use (custom notifications)
+}

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikLanguageServer.java
@@ -34,7 +34,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
   private final MagikTextDocumentService magikTextDocumentService;
   private final MagikWorkspaceService magikWorkspaceService;
   private final MagikNotebookDocumentService magikNotebookDocumentService;
-  private LanguageClient languageClient;
+  private MagikLanguageClient languageClient;
 
   /**
    * Constructor.
@@ -146,7 +146,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
 
   @Override
   public void connect(final LanguageClient newLanguageClient) {
-    this.languageClient = newLanguageClient;
+    this.languageClient = (MagikLanguageClient) newLanguageClient;
   }
 
   /**
@@ -154,7 +154,7 @@ public class MagikLanguageServer implements LanguageServer, LanguageClientAware 
    *
    * @return Language client.
    */
-  public LanguageClient getLanguageClient() {
+  public MagikLanguageClient getLanguageClient() {
     return this.languageClient;
   }
 

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -7,6 +7,7 @@ import java.net.SocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -122,7 +123,7 @@ public final class Main {
               wrapper);
     }
 
-    assert launcher != null;
+    Objects.requireNonNull(launcher, "Could not create LSP launcher");
     final LanguageClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -12,7 +12,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -29,7 +34,11 @@ public final class Main {
   private static final Option OPTION_NET =
       Option.builder()
           .longOpt("net")
-          .desc("Open the LSP on port 5007 instead of using STDIN for commands")
+          .desc("Open the LSP on a port instead of using STDIN for commands (default: 5007)")
+          .hasArg()
+          .optionalArg(true)
+          .type(Integer.class)
+          .argName("PORT")
           .build();
 
   static {
@@ -94,10 +103,12 @@ public final class Main {
     Launcher<MagikLanguageClient> launcher;
     Function<MessageConsumer, MessageConsumer> wrapper = consumer -> (MessageConsumer) consumer;
     if (commandLine.hasOption(OPTION_NET)) {
+      int port = commandLine.getParsedOptionValue(OPTION_NET, 5007);
+      System.out.println("Launching LSP on port " + port);
       launcher =
           createSocketLauncher(
               server,
-              new InetSocketAddress("localhost", 5007),
+              new InetSocketAddress("localhost", port),
               Executors.newCachedThreadPool(),
               wrapper);
     } else {

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -2,16 +2,21 @@ package nl.ramsolutions.sw.magik.languageserver;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.AsynchronousServerSocketChannel;
+import java.nio.channels.AsynchronousSocketChannel;
+import java.nio.channels.Channels;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
 import java.util.logging.LogManager;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 /** Main entry point. */
 public final class Main {
@@ -20,15 +25,18 @@ public final class Main {
   private static final Option OPTION_DEBUG =
       Option.builder().longOpt("debug").desc("Show debug messages").build();
   private static final Option OPTION_STDIO =
+      Option.builder().longOpt("stdio").desc("Use STDIO (default)").build();
+  private static final Option OPTION_NET =
       Option.builder()
-          .longOpt("stdio")
-          .desc("Use STDIO (default, no other option to interface with this language server)")
+          .longOpt("net")
+          .desc("Open the LSP on port 5007 instead of using STDIN for commands")
           .build();
 
   static {
     OPTIONS = new Options();
     OPTIONS.addOption(OPTION_DEBUG);
     OPTIONS.addOption(OPTION_STDIO);
+    OPTIONS.addOption(OPTION_NET);
   }
 
   private Main() {}
@@ -83,12 +91,54 @@ public final class Main {
     }
 
     final MagikLanguageServer server = new MagikLanguageServer();
-    final Launcher<LanguageClient> launcher =
-        LSPLauncher.createServerLauncher(server, System.in, System.out); // NOSONAR
+    Launcher<MagikLanguageClient> launcher;
+    Function<MessageConsumer, MessageConsumer> wrapper = consumer -> (MessageConsumer) consumer;
+    if (commandLine.hasOption(OPTION_NET)) {
+      launcher =
+          createSocketLauncher(
+              server,
+              new InetSocketAddress("localhost", 5007),
+              Executors.newCachedThreadPool(),
+              wrapper);
+    } else {
+      launcher =
+          Launcher.createIoLauncher(
+              server,
+              MagikLanguageClient.class,
+              System.in,
+              System.out,
+              Executors.newCachedThreadPool(),
+              wrapper);
+    }
 
+    assert launcher != null;
     final LanguageClient remoteProxy = launcher.getRemoteProxy();
     server.connect(remoteProxy);
 
     launcher.startListening();
+  }
+
+  static Launcher<MagikLanguageClient> createSocketLauncher(
+      LanguageServer languageServer,
+      SocketAddress socketAddress,
+      ExecutorService executorService,
+      Function<MessageConsumer, MessageConsumer> wrapper)
+      throws IOException {
+    AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress);
+    AsynchronousSocketChannel socketChannel;
+    try {
+      socketChannel = serverSocket.accept().get();
+      return Launcher.createIoLauncher(
+          languageServer,
+          MagikLanguageClient.class,
+          Channels.newInputStream(socketChannel),
+          Channels.newOutputStream(socketChannel),
+          executorService,
+          wrapper);
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+    return null;
   }
 }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/Main.java
@@ -124,20 +124,21 @@ public final class Main {
       ExecutorService executorService,
       Function<MessageConsumer, MessageConsumer> wrapper)
       throws IOException {
-    AsynchronousServerSocketChannel serverSocket =
-        AsynchronousServerSocketChannel.open().bind(socketAddress);
-    AsynchronousSocketChannel socketChannel;
-    try {
-      socketChannel = serverSocket.accept().get();
-      return Launcher.createIoLauncher(
-          languageServer,
-          MagikLanguageClient.class,
-          Channels.newInputStream(socketChannel),
-          Channels.newOutputStream(socketChannel),
-          executorService,
-          wrapper);
-    } catch (InterruptedException | ExecutionException e) {
-      e.printStackTrace();
+    try (AsynchronousServerSocketChannel serverSocket =
+        AsynchronousServerSocketChannel.open().bind(socketAddress)) {
+      AsynchronousSocketChannel socketChannel;
+      try {
+        socketChannel = serverSocket.accept().get();
+        return Launcher.createIoLauncher(
+            languageServer,
+            MagikLanguageClient.class,
+            Channels.newInputStream(socketChannel),
+            Channels.newOutputStream(socketChannel),
+            executorService,
+            wrapper);
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
     }
     return null;
   }


### PR DESCRIPTION
Hi Steven,

this PR changes the way that the name of a call stack element is evaluated -> it ignores if the package cannot be found. I also added that the Debug Adapter actually quits the program if the client disconnects.

I also added documentation in the README for debugging Smallworld Sessions on Windows because in my experience the debug agent always uses the port 32000, no matter what you specify.

This should be merged after #200.