### PR TITLE
Add rangeFormatting to formattingProvider

### DIFF
--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
@@ -51,6 +51,7 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.FoldingRange;
@@ -658,6 +659,41 @@ public class MagikTextDocumentService implements TextDocumentService {
           if (LOGGER_DURATION.isTraceEnabled()) {
             LOGGER_DURATION.trace(
                 "Duration: {} formatting, uri: {}",
+                String.format("%.3f", (System.nanoTime() - start) / 1000000000.0),
+                textDocument.getUri());
+          }
+          return textEdits;
+        });
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> rangeFormatting(
+      DocumentRangeFormattingParams params) {
+    final long start = System.nanoTime();
+
+    final TextDocumentIdentifier textDocument = params.getTextDocument();
+    LOGGER.debug("rangeFormatting, uri: {}", textDocument.getUri());
+
+    final OpenedFile openedFile = this.openedFiles.get(textDocument);
+    if (!(openedFile instanceof MagikTypedFile)) {
+      return CompletableFuture.supplyAsync(Collections::emptyList);
+    }
+
+    final MagikTypedFile magikFile = (MagikTypedFile) openedFile;
+    final FormattingOptions options = params.getOptions();
+    final Range range = params.getRange();
+    return CompletableFuture.supplyAsync(
+        () -> {
+          if (!this.formattingProvider.canFormat(magikFile)) {
+            LOGGER.warn("Cannot format due to syntax error");
+            return Collections.emptyList();
+          }
+
+          final List<TextEdit> textEdits =
+              this.formattingProvider.provideRangeFormatting(magikFile, options, range);
+          if (LOGGER_DURATION.isTraceEnabled()) {
+            LOGGER_DURATION.trace(
+                "Duration: {} rangeFormatting, uri: {}",
                 String.format("%.3f", (System.nanoTime() - start) / 1000000000.0),
                 textDocument.getUri());
           }

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
@@ -682,6 +682,7 @@ public class MagikTextDocumentService implements TextDocumentService {
     final MagikTypedFile magikFile = (MagikTypedFile) openedFile;
     final FormattingOptions options = params.getOptions();
     final Range range = params.getRange();
+    final nl.ramsolutions.sw.magik.Range magikRange = Lsp4jConversion.rangeFromLsp4j(range);
     return CompletableFuture.supplyAsync(
         () -> {
           if (!this.formattingProvider.canFormat(magikFile)) {
@@ -690,7 +691,7 @@ public class MagikTextDocumentService implements TextDocumentService {
           }
 
           final List<TextEdit> textEdits =
-              this.formattingProvider.provideRangeFormatting(magikFile, options, range);
+              this.formattingProvider.provideRangeFormatting(magikFile, options, magikRange);
           if (LOGGER_DURATION.isTraceEnabled()) {
             LOGGER_DURATION.trace(
                 "Duration: {} rangeFormatting, uri: {}",

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
@@ -8,18 +8,17 @@ import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import nl.ramsolutions.sw.magik.formatting.FormattingWalker;
 import nl.ramsolutions.sw.magik.languageserver.Lsp4jConversion;
 import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Formatting provider. */
 public class FormattingProvider {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FormattingProvider.class);
-
   public void setCapabilities(final ServerCapabilities capabilities) {
     capabilities.setDocumentFormattingProvider(true);
+    capabilities.setDocumentRangeFormattingProvider(true);
   }
 
   /**
@@ -40,6 +39,49 @@ public class FormattingProvider {
     walker.walkAst(node);
     final List<nl.ramsolutions.sw.magik.TextEdit> textEdits = walker.getTextEdits();
     return textEdits.stream().map(Lsp4jConversion::textEditToLsp4j).toList();
+  }
+
+  /**
+   * Provide formatting for text in range.
+   *
+   * @param magikFile Magik file.
+   * @param options Formatting options.
+   * @param range Range.
+   * @return {@link TextEdit}s.
+   * @throws IOException -
+   */
+  public List<TextEdit> provideRangeFormatting(
+      final MagikFile magikFile, final FormattingOptions options, final Range range) {
+    final List<org.eclipse.lsp4j.TextEdit> textEdits = this.provideFormatting(magikFile, options);
+    return textEdits.stream().filter(edit -> isEditInRange(edit, range)).toList();
+  }
+
+  /**
+   * Test if a given text edit's range intersects with the specified range.
+   *
+   * @param edit the text edit to check
+   * @param range the range to check against
+   * @return true if the text edit's range intersects with the specified range, false otherwise
+   */
+  private boolean isEditInRange(TextEdit edit, Range range) {
+    return isPositionInRange(edit.getRange().getStart(), range)
+        || isPositionInRange(edit.getRange().getEnd(), range);
+  }
+
+  /**
+   * Test if a given position is within the specified range.
+   *
+   * @param position the position to check
+   * @param range the range to check against
+   * @return true if the position is within the specified range, false otherwise
+   */
+  private boolean isPositionInRange(Position position, Range range) {
+    return (position.getLine() > range.getStart().getLine()
+            || (position.getLine() == range.getStart().getLine()
+                && position.getCharacter() >= range.getStart().getCharacter()))
+        && (position.getLine() < range.getEnd().getLine()
+            || (position.getLine() == range.getEnd().getLine()
+                && position.getCharacter() <= range.getEnd().getCharacter()));
   }
 
   /**

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
@@ -4,7 +4,6 @@ import com.sonar.sslr.api.AstNode;
 import java.io.IOException;
 import java.util.List;
 import nl.ramsolutions.sw.magik.MagikFile;
-import nl.ramsolutions.sw.magik.Position;
 import nl.ramsolutions.sw.magik.Range;
 import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import nl.ramsolutions.sw.magik.formatting.FormattingWalker;
@@ -53,21 +52,21 @@ public class FormattingProvider {
   public List<TextEdit> provideRangeFormatting(
       final MagikFile magikFile, final FormattingOptions options, final Range range) {
     final List<org.eclipse.lsp4j.TextEdit> textEdits = this.provideFormatting(magikFile, options);
-    return textEdits.stream().filter(edit -> isEditInRange(edit, range)).toList();
+    return textEdits.stream().filter(edit -> this.isEditInRange(edit, range)).toList();
   }
 
   /**
-   * Test if a given text edit's range intersects with the specified range.
+   * Test if a given text edit's range overlaps with the specified range.
    *
    * @param edit the text edit to check
    * @param range the range to check against
-   * @return true if the text edit's range intersects with the specified range, false otherwise
+   * @return true if the text edit's range overlaps with the specified range, false otherwise
    */
   private boolean isEditInRange(TextEdit edit, Range range) {
-    Position editStart = Lsp4jConversion.positionFromLsp4j(edit.getRange().getStart());
-    Position editEnd = Lsp4jConversion.positionFromLsp4j(edit.getRange().getEnd());
+    final org.eclipse.lsp4j.Range editRange = edit.getRange();
+    final Range editMagikRange = Lsp4jConversion.rangeFromLsp4j(editRange);
 
-    return !editEnd.isBeforeRange(range) && !editStart.isAfterRange(range);
+    return range.overlapsWith(editMagikRange);
   }
 
   /**

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProvider.java
@@ -4,12 +4,12 @@ import com.sonar.sslr.api.AstNode;
 import java.io.IOException;
 import java.util.List;
 import nl.ramsolutions.sw.magik.MagikFile;
+import nl.ramsolutions.sw.magik.Position;
+import nl.ramsolutions.sw.magik.Range;
 import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import nl.ramsolutions.sw.magik.formatting.FormattingWalker;
 import nl.ramsolutions.sw.magik.languageserver.Lsp4jConversion;
 import org.eclipse.lsp4j.FormattingOptions;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
 
@@ -64,24 +64,10 @@ public class FormattingProvider {
    * @return true if the text edit's range intersects with the specified range, false otherwise
    */
   private boolean isEditInRange(TextEdit edit, Range range) {
-    return isPositionInRange(edit.getRange().getStart(), range)
-        || isPositionInRange(edit.getRange().getEnd(), range);
-  }
+    Position editStart = Lsp4jConversion.positionFromLsp4j(edit.getRange().getStart());
+    Position editEnd = Lsp4jConversion.positionFromLsp4j(edit.getRange().getEnd());
 
-  /**
-   * Test if a given position is within the specified range.
-   *
-   * @param position the position to check
-   * @param range the range to check against
-   * @return true if the position is within the specified range, false otherwise
-   */
-  private boolean isPositionInRange(Position position, Range range) {
-    return (position.getLine() > range.getStart().getLine()
-            || (position.getLine() == range.getStart().getLine()
-                && position.getCharacter() >= range.getStart().getCharacter()))
-        && (position.getLine() < range.getEnd().getLine()
-            || (position.getLine() == range.getEnd().getLine()
-                && position.getCharacter() <= range.getEnd().getCharacter()));
+    return !editEnd.isBeforeRange(range) && !editStart.isAfterRange(range);
   }
 
   /**

--- a/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProviderTest.java
+++ b/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProviderTest.java
@@ -30,6 +30,21 @@ class FormattingProviderTest {
     return provider.provideFormatting(magikFile, options);
   }
 
+  private List<TextEdit> getRangeEdits(final String code, final Range range) {
+    final FormattingOptions options = new FormattingOptions();
+    return this.getRangeEdits(code, options, range);
+  }
+
+  private List<TextEdit> getRangeEdits(
+      final String code, final FormattingOptions options, final Range range) {
+    final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
+    final MagikTypedFile magikFile =
+        new MagikTypedFile(MagikTypedFile.DEFAULT_URI, code, definitionKeeper);
+
+    final FormattingProvider provider = new FormattingProvider();
+    return provider.provideRangeFormatting(magikFile, options, range);
+  }
+
   @Test
   void testFormattingSomething() {
     final String code =
@@ -50,6 +65,31 @@ class FormattingProviderTest {
         _endmethod
         """;
     final List<TextEdit> edits = this.getEdits(code);
+    assertThat(edits).isEmpty();
+  }
+
+  @Test
+  void testFormattingSomethingInsideRange() {
+    final String code =
+        """
+        _method a. b(x, y, z)
+        _endmethod
+        """;
+    final Range range = new Range(new Position(0, 0), new Position(0, 12));
+    final List<TextEdit> edits = this.getRangeEdits(code, range);
+    assertThat(edits)
+        .containsExactly(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
+  }
+
+  @Test
+  void testFormattingNothingOutsideOfRange() {
+    final String code =
+        """
+        _method a. b(x, y, z)
+        _endmethod
+        """;
+    final Range range = new Range(new Position(1, 0), new Position(1, 10));
+    final List<TextEdit> edits = this.getRangeEdits(code, range);
     assertThat(edits).isEmpty();
   }
 }

--- a/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProviderTest.java
+++ b/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/formatting/FormattingProviderTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import nl.ramsolutions.sw.magik.MagikTypedFile;
 import nl.ramsolutions.sw.magik.analysis.definitions.DefinitionKeeper;
 import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
+import nl.ramsolutions.sw.magik.languageserver.Lsp4jConversion;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -30,13 +31,16 @@ class FormattingProviderTest {
     return provider.provideFormatting(magikFile, options);
   }
 
-  private List<TextEdit> getRangeEdits(final String code, final Range range) {
+  private List<TextEdit> getRangeEdits(
+      final String code, final nl.ramsolutions.sw.magik.Range range) {
     final FormattingOptions options = new FormattingOptions();
     return this.getRangeEdits(code, options, range);
   }
 
   private List<TextEdit> getRangeEdits(
-      final String code, final FormattingOptions options, final Range range) {
+      final String code,
+      final FormattingOptions options,
+      final nl.ramsolutions.sw.magik.Range range) {
     final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
     final MagikTypedFile magikFile =
         new MagikTypedFile(MagikTypedFile.DEFAULT_URI, code, definitionKeeper);
@@ -76,7 +80,8 @@ class FormattingProviderTest {
         _endmethod
         """;
     final Range range = new Range(new Position(0, 0), new Position(0, 12));
-    final List<TextEdit> edits = this.getRangeEdits(code, range);
+    final nl.ramsolutions.sw.magik.Range magikRange = Lsp4jConversion.rangeFromLsp4j(range);
+    final List<TextEdit> edits = this.getRangeEdits(code, magikRange);
     assertThat(edits)
         .containsExactly(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
   }
@@ -89,7 +94,8 @@ class FormattingProviderTest {
         _endmethod
         """;
     final Range range = new Range(new Position(1, 0), new Position(1, 10));
-    final List<TextEdit> edits = this.getRangeEdits(code, range);
+    final nl.ramsolutions.sw.magik.Range magikRange = Lsp4jConversion.rangeFromLsp4j(range);
+    final List<TextEdit> edits = this.getRangeEdits(code, magikRange);
     assertThat(edits).isEmpty();
   }
 }


### PR DESCRIPTION
Right now we could only format the whole document, which could lead to an enormous list of changes. This makes it more controllable where you want to format.