### PR TITLE
Be compliant for publish to SonarQube Marketplace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 
   <name>Magik Tools</name>
   <description>Collection of tools for Magik development</description>
+  <url>https://github.com/StevenLooman/magik-tools</url>
 
   <modules>
     <module>magik-checks</module>
@@ -44,6 +45,11 @@
     <url>https://github.com/StevenLooman/magik-tools</url>
     <tag>HEAD</tag>
   </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/StevenLooman/magik-tools/issues</url>
+  </issueManagement>
 
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>

--- a/sonar-magik-plugin/pom.xml
+++ b/sonar-magik-plugin/pom.xml
@@ -102,7 +102,7 @@
 
         <configuration>
           <pluginClass>nl.ramsolutions.sw.sonar.MagikPlugin</pluginClass>
-          <pluginName>Magik Code Quality and Security</pluginName>
+          <pluginName>Magik</pluginName>
           <pluginKey>communitymagik</pluginKey>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>false</sonarLintSupported>

--- a/sonar-magik-plugin/pom.xml
+++ b/sonar-magik-plugin/pom.xml
@@ -17,7 +17,6 @@
   <properties>
     <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
     <artifactsToPublish>${project.groupId}:sonar-magik-plugin:jar</artifactsToPublish>
-    <sonar.pluginKey>communitymagik</sonar.pluginKey>
   </properties>
 
   <dependencies>
@@ -104,7 +103,7 @@
         <configuration>
           <pluginClass>nl.ramsolutions.sw.sonar.MagikPlugin</pluginClass>
           <pluginName>Magik Code Quality and Security</pluginName>
-          <pluginKey>magik</pluginKey>
+          <pluginKey>communitymagik</pluginKey>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>false</sonarLintSupported>
           <pluginApiMinVersion>${pluginApiMinVersion}</pluginApiMinVersion>

--- a/sonar-magik-plugin/pom.xml
+++ b/sonar-magik-plugin/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
     <artifactsToPublish>${project.groupId}:sonar-magik-plugin:jar</artifactsToPublish>
+    <sonar.pluginKey>communitymagik</sonar.pluginKey>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Ref: https://github.com/SonarSource/sonar-update-center-properties#create-file:

> File name should correspond to plugin's pluginKey and end with a .properties extension. Plugin key is set in the plugin module's pom (not the top-level pom):
> * Explicitly in a `sonar.pluginKey` property. This is the first choice / preferred
> * Implicitly by the artifactId:
>   * `sonar-{pluginKey}-plugin`
>   * when the `sonar-x-plugin` pattern is not used for the artifactId, the plugin key will be the whole artifact id.

Ref: https://community.sonarsource.com/t/deploying-to-the-marketplace/35236 - see 3.5:

> The key of your plugin must be:
> 1. short and unique
> 2. lowercase (no camelcase)
> 3. composed only of [a-z0-9]
> 4. related to the name of your plugin
> 5. not just the name of a language (e.g. cannot be java, rust, js/javascript, …) examples of good keys: motionchart, communityphp, scmactivity