### PR TITLE
Better handle `_scatter` in simple_vectors and arguments

### DIFF
--- a/changes/343.bugfix.md
+++ b/changes/343.bugfix.md
@@ -1,0 +1,3 @@
+Better handle `_scatter` in simple_vectors and arguments.
+
+Now something like `{_scatter b, _scatter v}` is marked as a syntax error.

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/api/MagikGrammar.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/api/MagikGrammar.java
@@ -316,7 +316,15 @@ public enum MagikGrammar implements GrammarRuleKey {
             MagikPunctuator.BRACE_L,
             b.firstOf(
                 b.sequence(
-                    b.optional(EXPRESSION, b.zeroOrMore(MagikPunctuator.COMMA, EXPRESSION)),
+                    b.optional(
+                        b.nextNot(MagikKeyword.SCATTER),
+                        EXPRESSION,
+                        b.zeroOrMore(
+                            MagikPunctuator.COMMA, b.nextNot(MagikKeyword.SCATTER), EXPRESSION)),
+                    b.optional(
+                        b.optional(MagikPunctuator.COMMA),
+                        b.next(MagikKeyword.SCATTER),
+                        EXPRESSION),
                     b.next(MagikPunctuator.BRACE_R)),
                 SIMPLE_VECTOR_SYNTAX_ERROR),
             MagikPunctuator.BRACE_R);
@@ -771,7 +779,12 @@ public enum MagikGrammar implements GrammarRuleKey {
                 b.sequence(
                     b.nextNot(MagikKeyword.OPTIONAL),
                     b.nextNot(MagikKeyword.GATHER),
-                    PARAMETERS,
+                    PARAMETER,
+                    b.zeroOrMore(
+                        MagikPunctuator.COMMA,
+                        b.nextNot(MagikKeyword.OPTIONAL),
+                        b.nextNot(MagikKeyword.GATHER),
+                        PARAMETER),
                     b.next(MagikPunctuator.SQUARE_R)),
                 PARAMETERS_SQUARE_SYNTAX_ERROR),
             MagikPunctuator.SQUARE_R);
@@ -832,7 +845,10 @@ public enum MagikGrammar implements GrammarRuleKey {
         .is(
             b.optional(
                 // Normal arguments.
-                b.optional(ARGUMENT, b.zeroOrMore(MagikPunctuator.COMMA, ARGUMENT)),
+                b.optional(
+                    b.nextNot(MagikKeyword.SCATTER),
+                    ARGUMENT,
+                    b.zeroOrMore(MagikPunctuator.COMMA, b.nextNot(MagikKeyword.SCATTER), ARGUMENT)),
                 b.optional(
                     b.optional(MagikPunctuator.COMMA), b.next(MagikKeyword.SCATTER), ARGUMENT)))
         .skip();

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/MagikGrammarTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/MagikGrammarTest.java
@@ -336,7 +336,8 @@ class MagikGrammarTest {
         .matches("{a, b, c, _scatter d}")
         .matches("{_scatter d}");
     MagikRuleRequiredAssert.assertThat(rule, MagikGrammar.SIMPLE_VECTOR_SYNTAX_ERROR)
-        .matches("{a, b, c, _scatter d, _scatter e}");
+        .matches("{a, b, c, _scatter d, _scatter e}")
+        .matches("{_scatter a, b}");
   }
 
   @Test

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/MagikGrammarTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/MagikGrammarTest.java
@@ -104,11 +104,29 @@ class MagikGrammarTest {
   }
 
   @Test
-  void testArguments() {
+  void testArgumentsParen() {
     final Rule rule = g.rule(MagikGrammar.ARGUMENTS_PAREN);
     MagikRuleForbiddenAssert.assertThat(rule, MagikGrammar.ARGUMENTS_PAREN_SYNTAX_ERROR)
         .matches("()")
-        .matches("(1, 2)");
+        .matches("(a, b)")
+        .matches("(a, _scatter b)")
+        .matches("(a _scatter b)");
+    MagikRuleRequiredAssert.assertThat(rule, MagikGrammar.ARGUMENTS_PAREN_SYNTAX_ERROR)
+        .matches("(a b)")
+        .matches("(_scatter a, _scatter b)");
+  }
+
+  @Test
+  void testArgumentsSquare() {
+    final Rule rule = g.rule(MagikGrammar.ARGUMENTS_SQUARE);
+    MagikRuleForbiddenAssert.assertThat(rule, MagikGrammar.ARGUMENTS_SQUARE_SYNTAX_ERROR)
+        .matches("[a]")
+        .matches("[a, b]")
+        .matches("[a, _scatter b]")
+        .matches("[a _scatter b]");
+    MagikRuleRequiredAssert.assertThat(rule, MagikGrammar.ARGUMENTS_SQUARE_SYNTAX_ERROR)
+        .matches("[a b]")
+        .matches("[_scatter a, _scatter b]");
   }
 
   @Test
@@ -305,6 +323,20 @@ class MagikGrammarTest {
         .matches("_primitive 1")
         .matches("_primitive 512")
         .notMatches("_primitive");
+  }
+
+  @Test
+  void testSimpleVector() {
+    final Rule rule = g.rule(MagikGrammar.SIMPLE_VECTOR);
+    MagikRuleForbiddenAssert.assertThat(rule, MagikGrammar.SIMPLE_VECTOR_SYNTAX_ERROR)
+        .matches("{}")
+        .matches("{a}")
+        .matches("{a, b}")
+        .matches("{a, b, c}")
+        .matches("{a, b, c, _scatter d}")
+        .matches("{_scatter d}");
+    MagikRuleRequiredAssert.assertThat(rule, MagikGrammar.SIMPLE_VECTOR_SYNTAX_ERROR)
+        .matches("{a, b, c, _scatter d, _scatter e}");
   }
 
   @Test


### PR DESCRIPTION
Better handle `_scatter` in simple_vectors and arguments.

Fixes #342.