### PR TITLE
Add code (name of the check) to Diagnostic

### DIFF
--- a/changes/372.feature.md
+++ b/changes/372.feature.md
@@ -1,3 +1,4 @@
 Add name of the check as code to the Diagnostic to provide more information.
 
-This information is used for example in Emacs for Flycheck when listing all errors in a file
+This information is used for example 
+in Emacs for Flycheck when listing all errors in a file.

--- a/changes/372.feature.md
+++ b/changes/372.feature.md
@@ -1,1 +1,3 @@
 Add name of the check as code to the Diagnostic to provide more information.
+
+This information is used for example in Emacs for Flycheck when listing all errors in a file

--- a/changes/372.feature.md
+++ b/changes/372.feature.md
@@ -1,0 +1,1 @@
+Add name of the check as code to the Diagnostic to provide more information.

--- a/changes/372.feature.md
+++ b/changes/372.feature.md
@@ -1,4 +1,4 @@
 Add name of the check as code to the Diagnostic to provide more information.
 
-This information is used for example 
+This information is used for example
 in Emacs for Flycheck when listing all errors in a file.

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/diagnostics/ChecksDiagnosticsProvider.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/diagnostics/ChecksDiagnosticsProvider.java
@@ -72,7 +72,7 @@ public class ChecksDiagnosticsProvider {
               final DiagnosticSeverity severity = this.getCheckSeverity(holder);
               final String checkKeyKebabCase = holder.getCheckKeyKebabCase();
               final String diagnosticSource = String.format("mlint (%s)", checkKeyKebabCase);
-              return new Diagnostic(range, message, severity, diagnosticSource);
+              return new Diagnostic(range, message, severity, diagnosticSource, checkKeyKebabCase);
             })
         .toList();
   }


### PR DESCRIPTION
Add name of the check as `code` to the `Diagnostic` to provide more information.

This information is used for example in Emacs for Flycheck when listing all errors in a file.