### PR TITLE
Add all (Typed)Checks to Wiki

### DIFF
--- a/.github/scripts/generate-checks-pages.py
+++ b/.github/scripts/generate-checks-pages.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
             html_to_markdown_converter.convert_to_markdown()
             html_to_markdown_converter.write_to_file(output_file_path)
 
-            if check_type == "Magik Typed Checks":
+            if check_type == "Magik typed checks":
               java_file = java_checks_folder.joinpath(f"{file_name}TypedCheck.java")
             else:
               java_file = java_checks_folder.joinpath(f"{file_name}Check.java")

--- a/.github/scripts/generate-checks-pages.py
+++ b/.github/scripts/generate-checks-pages.py
@@ -5,215 +5,148 @@ from pathlib import Path
 import re
 import json
 
-class Writer:
-    FOOTER_NOTE = "\n> [!NOTE]\n> This page is generated. Any changes made to this page through the wiki will be lost in the future.\n"
+FOOTER_NOTE = """\n> [!NOTE]\n> This page is generated. Any changes made to this page through the wiki will be lost in the future.\n"""
 
-    def __init__(self, file_path: Path):
-        """
-        Initialize the Writer class with output file path.
-        """
-        self.file_path = file_path
-
-    def write_footer(self):
-        """
-        Write the footer to the file.
-        """
-        self.write_to_file(self.FOOTER_NOTE)
-
-    def write_to_file(self, content: str):
-        """
-        Write the content to the file.
-        """
-        with self.file_path.open(mode="a", encoding="utf-8") as file:
-            file.write(content)
+TABLE_HEADER = """\n## Options\n\n| Option | Default value | Description |\n|--------|---------------|-------------|"""
 
 
-class HTMLToMarkdown:
-    def __init__(self, file_path: Path):
-        """
-        Initialize the HTMLToMarkdown class with HTML file path.
-        """
-        self.file_path = file_path
-        self.markdown_content = None
-
-    def convert_to_markdown(self):
-        """
-        Convert the HTML content to Markdown using html2text.
-        """
-        html_content = self.file_path.read_text()
-        converter = html2text.HTML2Text()
-        converter.body_width = 0
-        markdown_content = converter.handle(html_content)
-        self.markdown_content = markdown_content
-
-    def write_to_file(self, file_path: Path):
-        """
-        Write the converted Markdown content to a file.
-        """
-        if self.markdown_content is None:
-            raise ValueError(
-                "Markdown content is not generated. Call convert_to_markdown() first."
-            )
-
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-
-        writer = Writer(file_path)
-        writer.write_to_file(self.markdown_content)
+def write_file(file_path: Path, content: str):
+    """Write (overwrite) content to a file."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content, encoding="utf-8")
 
 
-class JavaToMarkdown:
-    RULE_PROPERTY_PATTERN = r"@RuleProperty\s*\(((?:[^()]|\([^()]*\))*?)\)"
-    DEFAULT_VALUE_PATTERN = r'defaultValue\s*=\s*""\s*\+\s*(DEFAULT_[^,\s]*)'
-    DEFAULT_VALUE_DIRECT_PATTERN = r'defaultValue\s*=\s*"([^"]*)"'
-    KEY_PATTERN = r'key\s*=\s*"([^"]*)"'
-    DESCRIPTION_PATTERN = r'description\s*=\s*"([^"]*)"'
-    KEBAB_CASE_PATTERN = r"(?<!^)(?=[A-Z])"
-    TABLE_HEADER = "\n## Options\n\n| Option | Default value | Description |\n|--------|---------------|-------------|"
-
-    def __init__(self, file_path: Path):
-        """
-        Initialize the JavaToMarkdown class with Java file_path.
-        """
-        self.file_path = file_path
-        self.markdown_content = None
-
-    def extract_default_value_from_property(self, content: str, property_text: str):
-        """ """
-        default_ref = re.search(self.DEFAULT_VALUE_PATTERN, property_text)
-        if default_ref:
-            constant_name = default_ref.group(1)
-            constant_pattern = (
-                f"private static final \\w+ {constant_name}\\s*=\\s*([^;]*?)\\s*;"
-            )
-            constant_match = re.search(constant_pattern, content, re.DOTALL)
-            if constant_match:
-                value = constant_match.group(1).replace("\n", "").replace('"', "")
-                clean_value = "".join(value.split()).replace("+", "")
-                return ",  ".join(item for item in clean_value.split(",") if item)
-
-        direct_value = re.search(self.DEFAULT_VALUE_DIRECT_PATTERN, property_text)
-        return direct_value.group(1) if direct_value else ""
-
-    def extract_rule_properties(self):
-        """
-        Extract the RuleProperty's from the given Java file_path.
-        """
-        java_content = self.file_path.read_text()
-        check_name = self.file_path.stem.replace("Check", "")
-        check_name_as_kebab_case = re.sub(
-            self.KEBAB_CASE_PATTERN, "-", check_name
-        ).lower()
-
-        properties = []
-
-        for property in re.finditer(
-            self.RULE_PROPERTY_PATTERN, java_content, re.DOTALL
-        ):
-            property_text = property.group(1)
-            option_name = (
-                re.search(self.KEY_PATTERN, property_text).group(1).replace(" ", "-")
-            )
-
-            check_name_with_option_name = f"{check_name_as_kebab_case}.{option_name}"
-            description = re.search(self.DESCRIPTION_PATTERN, property_text).group(1)
-            default_value = self.extract_default_value_from_property(
-                java_content, property_text
-            )
-
-            properties.append(
-                f"| {check_name_with_option_name} | {default_value} | {description} |"
-            )
-
-        return properties
-
-    def convert_to_markdown(self):
-        """
-        Convert the Java content to Markdown by extracting the RuleProperty information.
-        """
-
-        properties = self.extract_rule_properties()
-        if properties != []:
-            properties.insert(0, self.TABLE_HEADER)
-            java_content = "\n".join(properties) + "\n"
-        else:
-            java_content = ""
-        self.markdown_content = java_content
-
-    def write_to_file(self, file_path: Path, append: bool = False):
-        """
-        Write the converted Java content to a file.
-        """
-        if self.markdown_content is None:
-            raise ValueError(
-                "Java content is not generated. Call convert_to_markdown() first."
-            )
-        elif self.markdown_content == "":
-            return
-
-        writer = Writer(file_path)
-        writer.write_to_file(self.markdown_content)
+def html_to_markdown(file_path: Path) -> str:
+    """Convert an HTML file to Markdown."""
+    html_content = file_path.read_text(encoding="utf-8")
+    converter = html2text.HTML2Text()
+    converter.body_width = 0
+    return converter.handle(html_content)
 
 
-if __name__ == "__main__":
+def extract_default_value(java_content: str, property_text: str) -> str:
+    """Extract default value from @RuleProperty."""
+    default_ref = re.search(
+        r'defaultValue\s*=\s*""\s*\+\s*(DEFAULT_[^,\s]*)', property_text
+    )
+    if default_ref:
+        constant_name = default_ref.group(1)
+        pattern = f"private static final \\w+ {constant_name}\\s*=\\s*([^;]*?)\\s*;"
+        match = re.search(pattern, java_content, re.DOTALL)
+        if match:
+            value = match.group(1).replace("\n", "").replace('"', "")
+            clean_value = "".join(value.split()).replace("+", "")
+            return ",  ".join(item for item in clean_value.split(",") if item)
+
+    direct = re.search(r'defaultValue\s*=\s*"([^"]*)"', property_text)
+    return direct.group(1) if direct else ""
+
+
+def extract_rule_properties(java_file: Path) -> list[str]:
+    """Extract @RuleProperty details from a Java file."""
+    java_content = java_file.read_text(encoding="utf-8")
+    check_name = java_file.stem.replace("Check", "")
+    kebab_case = re.sub(r"(?<!^)(?=[A-Z])", "-", check_name).lower()
+
+    props = []
+    for prop in re.finditer(
+        r"@RuleProperty\s*\(((?:[^()]|\([^()]*\))*?)\)", java_content, re.DOTALL
+    ):
+        text = prop.group(1)
+        key_match = re.search(r'key\s*=\s*"([^"]*)"', text)
+        desc_match = re.search(r'description\s*=\s*"([^"]*)"', text)
+        if not key_match or not desc_match:
+            continue
+
+        option_name = key_match.group(1).replace(" ", "-")
+        description = desc_match.group(1)
+        default_value = extract_default_value(java_content, text)
+
+        props.append(
+            f"| {kebab_case}.{option_name} | {default_value} | {description} |"
+        )
+
+    return props
+
+
+def java_to_markdown(java_file: Path) -> str:
+    """Convert Java @RuleProperty annotations to Markdown table."""
+    properties = extract_rule_properties(java_file)
+    if not properties:
+        return ""
+    return "\n".join([TABLE_HEADER, *properties, ""]) + "\n"
+
+
+def generate_markdown_pages():
     output_folder = Path("wiki/checks")
     output_folder.mkdir(parents=True, exist_ok=True)
-
-    index_file_path = output_folder / "Checks-Index.md"
-
-    index_writer = Writer(index_file_path)
-    index_writer.write_to_file("# Available checks\n")
+    index_file = output_folder / "Checks-Index.md"
+    index_content = ["# Available checks\n"]
 
     CHECK_TYPES = {
         "Magik checks": (
             Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/magik"),
-            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magik/rules")
+            Path(
+                "magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magik/rules"
+            ),
         ),
         "Magik typed checks": (
             Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped"),
-            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules")
+            Path(
+                "magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules"
+            ),
         ),
         "module.def checks": (
             Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/moduledef"),
-            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/moduledef/rules")
+            Path(
+                "magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/moduledef/rules"
+            ),
         ),
         "product.def checks": (
             Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/productdef"),
-            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/productdef/rules")
+            Path(
+                "magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/productdef/rules"
+            ),
         ),
     }
 
-    for check_type, (java_checks_folder, sonar_rules_folder) in CHECK_TYPES.items():
-        index_writer.write_to_file(f"\n## {check_type}\n\n")
+    for check_type, (java_folder, sonar_folder) in CHECK_TYPES.items():
+        index_content.append(f"\n## {check_type}\n\n")
 
-        for html_file_path in sorted(sonar_rules_folder.glob("*.html")):
-            file_name = html_file_path.stem
-            output_file_path = output_folder.joinpath(f"Check-{file_name}.md")
+        for json_file in sorted(sonar_folder.glob("*.json")):
+            file_name = json_file.stem
+            output_file = output_folder / f"Check-{file_name}.md"
+            print(f"Generating {output_file}.")
 
-            print(f"Generating {output_file_path}")
-
-            json_file_path = sonar_rules_folder / f"{file_name}.json"
-            json_text = json_file_path.read_text()
-            metadata = json.loads(json_text)
+            json_content = json_file.read_text(encoding="utf-8")
+            metadata = json.loads(json_content)
             title = metadata.get("sqKey", file_name)
 
-            writer = Writer(output_file_path)
-            writer.write_to_file(f"<!-- markdownlint-disable MD013 MD024 -->\n# `{title}` - ")
+            html_file = sonar_folder / f"{file_name}.html"
+            html_parts = html_to_markdown(html_file)
 
-            html_to_markdown_converter = HTMLToMarkdown(html_file_path)
-            html_to_markdown_converter.convert_to_markdown()
-            html_to_markdown_converter.write_to_file(output_file_path)
+            java_file = java_folder / (
+                f"{file_name}TypedCheck.java"
+                if check_type == "Magik typed checks"
+                else f"{file_name}Check.java"
+            )
+            java_parts = java_to_markdown(java_file)
 
-            if check_type == "Magik typed checks":
-              java_file = java_checks_folder.joinpath(f"{file_name}TypedCheck.java")
-            else:
-              java_file = java_checks_folder.joinpath(f"{file_name}Check.java")
+            parts = [
+                "<!-- markdownlint-disable MD013 MD024 -->",
+                f"# `{title}` - " + html_parts,
+                java_parts,
+                FOOTER_NOTE,
+            ]
 
-            java_to_markdown_converter = JavaToMarkdown(java_file)
-            java_to_markdown_converter.convert_to_markdown()
-            java_to_markdown_converter.write_to_file(output_file_path)
+            joined_parts = "\n".join(part for part in parts if part)
 
-            writer.write_footer()
+            write_file(output_file, joined_parts)
+            index_content.append(f"- **[{title}](Check-{file_name})**\n")
 
-            index_writer.write_to_file(f"- **[{title}](Check-{file_name})**\n")
+    index_content.append(FOOTER_NOTE)
+    write_file(index_file, "".join(index_content))
 
-    index_writer.write_footer()
+
+if __name__ == "__main__":
+    generate_markdown_pages()

--- a/.github/scripts/generate-checks-pages.py
+++ b/.github/scripts/generate-checks-pages.py
@@ -20,12 +20,11 @@ class Writer:
         """
         self.write_to_file(self.FOOTER_NOTE)
 
-    def write_to_file(self, content: str, overwrite: bool = False):
+    def write_to_file(self, content: str):
         """
         Write the content to the file.
         """
-        mode = "w" if overwrite else "a"
-        with self.file_path.open(mode=mode, encoding="utf-8") as file:
+        with self.file_path.open(mode="a", encoding="utf-8") as file:
             file.write(content)
 
 
@@ -47,7 +46,7 @@ class HTMLToMarkdown:
         markdown_content = converter.handle(html_content)
         self.markdown_content = markdown_content
 
-    def write_to_file(self, file_path: Path, overwrite: bool = False):
+    def write_to_file(self, file_path: Path):
         """
         Write the converted Markdown content to a file.
         """
@@ -59,7 +58,7 @@ class HTMLToMarkdown:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         writer = Writer(file_path)
-        writer.write_to_file(self.markdown_content, overwrite)
+        writer.write_to_file(self.markdown_content)
 
 
 class JavaToMarkdown:
@@ -140,7 +139,7 @@ class JavaToMarkdown:
             java_content = ""
         self.markdown_content = java_content
 
-    def write_to_file(self, file_path: Path, overwrite: bool = False):
+    def write_to_file(self, file_path: Path, append: bool = False):
         """
         Write the converted Java content to a file.
         """
@@ -152,7 +151,7 @@ class JavaToMarkdown:
             return
 
         writer = Writer(file_path)
-        writer.write_to_file(self.markdown_content, overwrite)
+        writer.write_to_file(self.markdown_content)
 
 
 if __name__ == "__main__":
@@ -162,7 +161,7 @@ if __name__ == "__main__":
     index_file_path = output_folder / "Checks-Index.md"
 
     index_writer = Writer(index_file_path)
-    index_writer.write_to_file("# Available checks\n", True)
+    index_writer.write_to_file("# Available checks\n")
 
     CHECK_TYPES = {
         "Magik checks": (
@@ -193,28 +192,26 @@ if __name__ == "__main__":
             print(f"Generating {output_file_path}")
 
             json_file_path = sonar_rules_folder / f"{file_name}.json"
-            if json_file_path.exists():
-                metadata = json.loads(json_file_path.read_text())
-                title = metadata.get("sqKey", file_name)
+            json_text = json_file_path.read_text()
+            metadata = json.loads(json_text)
+            title = metadata.get("sqKey", file_name)
 
             writer = Writer(output_file_path)
-            writer.write_to_file(f"<!-- markdownlint-disable MD013 MD024 -->\n# `{title}` - ", True)
+            writer.write_to_file(f"<!-- markdownlint-disable MD013 MD024 -->\n# `{title}` - ")
 
-            converter = HTMLToMarkdown(html_file_path)
-            converter.convert_to_markdown()
-            converter.write_to_file(output_file_path)
+            html_to_markdown_converter = HTMLToMarkdown(html_file_path)
+            html_to_markdown_converter.convert_to_markdown()
+            html_to_markdown_converter.write_to_file(output_file_path)
 
             if check_type == "Magik Typed Checks":
               java_file = java_checks_folder.joinpath(f"{file_name}TypedCheck.java")
             else:
               java_file = java_checks_folder.joinpath(f"{file_name}Check.java")
 
-            if java_file.exists():
-                converter = JavaToMarkdown(java_file)
-                converter.convert_to_markdown()
-                converter.write_to_file(output_file_path)
+            java_to_markdown_converter = JavaToMarkdown(java_file)
+            java_to_markdown_converter.convert_to_markdown()
+            java_to_markdown_converter.write_to_file(output_file_path)
 
-            writer = Writer(output_file_path)
             writer.write_footer()
 
             index_writer.write_to_file(f"- **[{title}](Check-{file_name})**\n")

--- a/.github/scripts/generate-checks-pages.py
+++ b/.github/scripts/generate-checks-pages.py
@@ -3,7 +3,7 @@
 import html2text
 from pathlib import Path
 import re
-
+import json
 
 class Writer:
     FOOTER_NOTE = "\n> [!NOTE]\n> This page is generated. Any changes made to this page through the wiki will be lost in the future.\n"
@@ -47,7 +47,7 @@ class HTMLToMarkdown:
         markdown_content = converter.handle(html_content)
         self.markdown_content = markdown_content
 
-    def write_to_file(self, file_path: Path, overwrite: bool):
+    def write_to_file(self, file_path: Path, overwrite: bool = False):
         """
         Write the converted Markdown content to a file.
         """
@@ -69,9 +69,7 @@ class JavaToMarkdown:
     KEY_PATTERN = r'key\s*=\s*"([^"]*)"'
     DESCRIPTION_PATTERN = r'description\s*=\s*"([^"]*)"'
     KEBAB_CASE_PATTERN = r"(?<!^)(?=[A-Z])"
-
-    TABLE_HEADER = "## Options\n\n| Option | Default value | Description |\n|--------|---------------|-------------|"
-
+    TABLE_HEADER = "\n## Options\n\n| Option | Default value | Description |\n|--------|---------------|-------------|"
 
     def __init__(self, file_path: Path):
         """
@@ -164,35 +162,61 @@ if __name__ == "__main__":
     index_file_path = output_folder / "Checks-Index.md"
 
     index_writer = Writer(index_file_path)
-    index_writer.write_to_file("# Available checks\n\n", True)
+    index_writer.write_to_file("# Available checks\n", True)
 
-    java_checks_folder = Path(
-        "magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks"
-    )
+    CHECK_TYPES = {
+        "Magik checks": (
+            Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/magik"),
+            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magik/rules")
+        ),
+        "Magik typed checks": (
+            Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped"),
+            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules")
+        ),
+        "module.def checks": (
+            Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/moduledef"),
+            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/moduledef/rules")
+        ),
+        "product.def checks": (
+            Path("magik-checks/src/main/java/nl/ramsolutions/sw/checks/productdef"),
+            Path("magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/productdef/rules")
+        ),
+    }
 
-    for html_file_path in sorted(
-        Path(
-            "magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magik/rules"
-        ).glob("*.html")
-    ):
-        html_file_name = html_file_path.stem
-        output_file_path = output_folder.joinpath(f"Check-{html_file_name}.md")
+    for check_type, (java_checks_folder, sonar_rules_folder) in CHECK_TYPES.items():
+        index_writer.write_to_file(f"\n## {check_type}\n\n")
 
-        print(f"Generating {output_file_path}")
+        for html_file_path in sorted(sonar_rules_folder.glob("*.html")):
+            file_name = html_file_path.stem
+            output_file_path = output_folder.joinpath(f"Check-{file_name}.md")
 
-        converter = HTMLToMarkdown(html_file_path)
-        converter.convert_to_markdown()
-        converter.write_to_file(output_file_path, True)
+            print(f"Generating {output_file_path}")
 
-        java_file = java_checks_folder.joinpath(f"{html_file_name}Check.java")
-        if java_file.exists():
-            converter = JavaToMarkdown(java_file)
+            json_file_path = sonar_rules_folder / f"{file_name}.json"
+            if json_file_path.exists():
+                metadata = json.loads(json_file_path.read_text())
+                title = metadata.get("sqKey", file_name)
+
+            writer = Writer(output_file_path)
+            writer.write_to_file(f"<!-- markdownlint-disable MD013 MD024 -->\n# `{title}` - ", True)
+
+            converter = HTMLToMarkdown(html_file_path)
             converter.convert_to_markdown()
             converter.write_to_file(output_file_path)
 
-        writer = Writer(output_file_path)
-        writer.write_footer()
+            if check_type == "Magik Typed Checks":
+              java_file = java_checks_folder.joinpath(f"{file_name}TypedCheck.java")
+            else:
+              java_file = java_checks_folder.joinpath(f"{file_name}Check.java")
 
-        index_writer.write_to_file(f"- [[{html_file_name}|Check-{html_file_name}]]\n")
+            if java_file.exists():
+                converter = JavaToMarkdown(java_file)
+                converter.convert_to_markdown()
+                converter.write_to_file(output_file_path)
+
+            writer = Writer(output_file_path)
+            writer.write_footer()
+
+            index_writer.write_to_file(f"- **[{title}](Check-{file_name})**\n")
 
     index_writer.write_footer()

--- a/.github/workflows/publish-checks-wiki.yml
+++ b/.github/workflows/publish-checks-wiki.yml
@@ -24,7 +24,11 @@ jobs:
       - run: |
           pip install -r .github/scripts/requirements.txt
           python3 .github/scripts/generate-checks-pages.py
-      - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
+      - uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: 'wiki/checks/*.md'
+          fix: true
+      - uses: Andrew-Chen-Wang/github-wiki-action@6448478bd55f1f3f752c93af8ac03207eccc3213 # v5.0.3
         with:
           path: wiki
           #dry-run: true

--- a/.github/workflows/publish-checks-wiki.yml
+++ b/.github/workflows/publish-checks-wiki.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           globs: 'wiki/checks/*.md'
           fix: true
-      - uses: Andrew-Chen-Wang/github-wiki-action@6448478bd55f1f3f752c93af8ac03207eccc3213 # v5.0.3
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           path: wiki
           #dry-run: true

--- a/changes/379.feature.md
+++ b/changes/379.feature.md
@@ -1,0 +1,4 @@
+Add the MagikTypedChecks, ModuleDefChecks and ProductDefChecks to the Wiki.
+
+Also improved the Markdown itself to have a better index if someone is searching
+for a specific check (based on the key).

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/AssignedTypeDoesNotMatchSlotType.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/AssignedTypeDoesNotMatchSlotType.html
@@ -1,0 +1,1 @@
+<p>Assigned type does not match slot type</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/AssignedTypeDoesNotMatchSlotType.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/AssignedTypeDoesNotMatchSlotType.html
@@ -1,1 +1,18 @@
 <p>Assigned type does not match slot type</p>
+<h2>Explanation</h2>
+<pre>
+## Example exemplar.
+## @slot {sw:rope} slot_1
+def_slotted_exemplar(
+        :example_exemplar,
+        {
+            {:slot_1, sw:rope}
+        })
+
+_method example_exemplar.example_method()
+    ## This assignment will raise an issue, because slot_1 is declared as sw:rope, but we are assigning an sw:integer.
+    .slot_1 << 12345
+_endmethod
+$
+</pre>
+<p>In the above example, in method <pre>example_exemplar.example_method()</pre>, we are trying to assign an integer value to a slot that is declared as a rope.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ComparedTypesDoNotMatch.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ComparedTypesDoNotMatch.html
@@ -1,1 +1,14 @@
 <p>Compared types do not match</p>
+<h2>Explanation</h2>
+<pre>
+_method a.m(param1)
+    ## @param {sw:integer} param1
+    _if param1 _is _unset
+    _then
+        # This condition will never be true, since param1 is defined as sw:integer,
+        # and can therefore never be sw:unset.
+    _endif
+_endmethod
+$
+</pre>
+<p>In the above example, we are trying to compare two different types: <pre>sw:integer</pre> and <pre>sw:unset</pre>. Given that the type definition of <pre>param1</pre> is <pre>sw:integer</pre>, it can never be <pre>sw:unset</pre>.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ComparedTypesDoNotMatch.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ComparedTypesDoNotMatch.html
@@ -1,0 +1,1 @@
+<p>Compared types do not match</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ConditionalExpressionIsFalse.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ConditionalExpressionIsFalse.html
@@ -1,1 +1,8 @@
 <p>Conditional expression does not result in true/false</p>
+<h2>Explanation</h2>
+<pre>
+_if :a
+_then
+_endif
+</pre>
+<p>In the above Magik code snippet, the conditional expression <pre>:a</pre> does not explicitly evaluate to <pre>sw:true</pre> or <pre>sw:false</pre>. In Magik, conditional expressions should result in a boolean value (true or false), otherwise this will result in an error.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ConditionalExpressionIsFalse.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ConditionalExpressionIsFalse.html
@@ -1,0 +1,1 @@
+<p>Conditional expression does not result in true/false</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedMethodUsage.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedMethodUsage.html
@@ -1,1 +1,15 @@
 <p>Deprecated method usage</p>
+<h2>Explanation</h2>
+<pre>
+_pragma(classify_level=deprecated)
+_method exemplar.example_method()
+_endmethod
+$
+
+_block
+    _local exem << exemplar
+    exem.example_method()
+_endblock
+$
+</pre>
+<p>In the example above, the method call <pre>exem.example_method()</pre> is marked as deprecated using the <pre>_pragma(classify_level=deprecated)</pre> directive.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedMethodUsage.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedMethodUsage.html
@@ -1,0 +1,1 @@
+<p>Deprecated method usage</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedTypeUsage.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedTypeUsage.html
@@ -1,1 +1,17 @@
 <p>Deprecated type usage</p>
+<h2>Explanation</h2>
+<pre>
+_pragma(classify_level=deprecated)
+## Example exemplar.
+def_slotted_exemplar(
+        :example_exemplar,
+        {
+        })
+$
+
+_block
+    example_exemplar.example_method()
+_endblock
+$
+</pre>
+<p>In the example, the use of <pre>example_exemplar</pre> is marked as deprecated, as the exemplar itself is marked as deprecated using the <pre>_pragma(classify_level=deprecated)</pre> directive.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedTypeUsage.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/DeprecatedTypeUsage.html
@@ -1,0 +1,1 @@
+<p>Deprecated type usage</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/GlobalExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/GlobalExists.html
@@ -1,0 +1,1 @@
+<p>Global exists</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/GlobalExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/GlobalExists.html
@@ -1,1 +1,10 @@
 <p>Global exists</p>
+<h2>Explanation</h2>
+<pre>
+_block
+    # non_existing_exemplar is a non-existing global/exemplar.
+    _local var << non_existing_exemplar.new()
+_endblock
+$
+</pre>
+<p>The global <pre>non_existing_exemplar</pre> in the example above does not exist.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentCountMatchesParameterCount.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentCountMatchesParameterCount.html
@@ -1,1 +1,13 @@
 <p>Method argument count matches parameter count</p>
+<h2>Explanation</h2>
+<pre>
+_method a.m(param1, param2)
+_endmethod
+$
+
+_block
+    a.m(1)
+_endblock
+$
+</pre>
+<p>The example above shows a call to method <pre>a.m()</pre>, but is missing argument <pre>param2</pre> when calling the method.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentCountMatchesParameterCount.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentCountMatchesParameterCount.html
@@ -1,0 +1,1 @@
+<p>Method argument count matches parameter count</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentTypeMatchesParameterType.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentTypeMatchesParameterType.html
@@ -1,0 +1,1 @@
+<p>Argument type does not match parameter type</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentTypeMatchesParameterType.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodArgumentTypeMatchesParameterType.html
@@ -1,1 +1,15 @@
 <p>Argument type does not match parameter type</p>
+<h2>Explanation</h2>
+<pre>
+_method a.m(param1, param2)
+    ## @param {sw:integer} param1
+    ## @param {sw:integer} param2
+_endmethod
+$
+
+_block
+    a.m(1, :a)
+_endblock
+$
+</pre>
+<p>The method <pre>a.m()</pre> is called with arguments of type <pre>sw:integer</pre> and <pre>sw:symbol</pre>, while the method expects <pre>sw:integer</pre> twice, as per method doc.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodExists.html
@@ -1,1 +1,9 @@
 <p>Method Exists</p>
+<h2>Explanation</h2>
+<pre>
+_block
+    rope.non_existing_method()
+_endblock
+$
+</pre>
+<p>Calling the method <pre>rope.non_existing_method()</pre> will result in an error, because the method does not exist.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodExists.html
@@ -1,0 +1,1 @@
+<p>Method Exists</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodIsPublic.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodIsPublic.html
@@ -1,1 +1,14 @@
 <p>Method Is Public</p>
+<h2>Explanation</h2>
+<pre>
+_private _method example_exemplar.private_example_method()
+    ## Private method which cannot be called from other methods or blocks.
+_endmethod
+$
+
+_block
+    example_exemplar.private_example_method()
+_endblock
+$
+</pre>
+<p>The call to <pre>example_exemplar.private_example_method()</pre> will result in an error, because the method is private and cannot be called from outside its own definition.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodIsPublic.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodIsPublic.html
@@ -1,0 +1,1 @@
+<p>Method Is Public</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodReturnTypesMatchDoc.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodReturnTypesMatchDoc.html
@@ -1,0 +1,1 @@
+<p>Method return types match doc</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodReturnTypesMatchDoc.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/MethodReturnTypesMatchDoc.html
@@ -1,1 +1,11 @@
 <p>Method return types match doc</p>
+<h2>Explanation</h2>
+<pre>
+_method example_exemplar.example_method()
+    ## Method returning an sw:integer.
+    ## @return {sw:integer} Returned value.
+    _return :symbol
+_endmethod
+$
+</pre>
+<p>This will raise an issue, because the method is documented to return an <pre>sw:integer</pre>, but actually returns a <pre>sw:symbol</pre>.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ModuleRequiredForGlobal.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ModuleRequiredForGlobal.html
@@ -1,0 +1,1 @@
+<p>Module required for used global</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ModuleRequiredForGlobal.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/ModuleRequiredForGlobal.html
@@ -1,1 +1,11 @@
 <p>Module required for used global</p>
+<h2>Explanation</h2>
+<pre>
+# Inside a module which does NOT require the appropriate module to get
+# the test_exemplar_from_another_module global variable.
+_block
+    _local var << test_exemplar_from_another_module
+_endblock
+$
+</pre>
+<p>This will raise an issue, because the <pre>test_exemplar_from_another_module</pre> might not be loaded, as the module containing this example code does not require the module which supplies the <pre>test_exemplar_from_another_module</pre>.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SlotExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SlotExists.html
@@ -1,0 +1,1 @@
+<p>Slot Exists</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SlotExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SlotExists.html
@@ -1,1 +1,17 @@
 <p>Slot Exists</p>
+<h2>Explanation</h2>
+<pre>
+## Example exemplar.
+def_slotted_exemplar(
+        :example_exemplar,
+        {
+            {:slot_a, _unset}
+        })
+
+_method example_exemplar.example_method()
+    ## This assignment will raise an issue, because slot_1 does not exist.
+    .slot_1 << 12345
+_endmethod
+$
+</pre>
+<p>In the method <pre>example_exemplar.example_method()</pre>, <pre>slot_1</pre> does not exist. Trying to use this slot will result in an error.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SwChar16VectorEvaluateInvocation.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SwChar16VectorEvaluateInvocation.html
@@ -1,1 +1,7 @@
 <p>Use of sw:char16_vector.evaluate()</p>
+<h2>Explanation</h2>
+<pre>
+_local user_input << "gis_program_manager.cached_dataset(:gis).collection(:very_important_data).empty()"
+user_input.evaluate()
+</pre>
+<p>The example shows the use of <code>sw:char16_vector.evaluate()</code> to execute user input as Magik code. This is dangerous as it can lead to code injection vulnerabilities if the user input is not properly sanitized.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SwChar16VectorEvaluateInvocation.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SwChar16VectorEvaluateInvocation.html
@@ -1,0 +1,1 @@
+<p>Use of sw:char16_vector.evaluate()</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/TypeDocTypeExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/TypeDocTypeExists.html
@@ -1,1 +1,9 @@
 <p>Type-doc Type Exists</p>
+<h2>Explanation</h2>
+<pre>
+_method a.b(p1)
+    ## @param {user:non_existing_exemplar} p1
+    ## @return {user:non_existing_exemplar}
+_endmethod
+</pre>
+<p>This check ensures that all types referenced in type-doc comments actually exist in the codebase. In the example above, both the parameter type and return type refer to a non-existing exemplar.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/TypeDocTypeExists.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/TypeDocTypeExists.html
@@ -1,0 +1,1 @@
+<p>Type-doc Type Exists</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/UndefinedMethodCallResult.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/UndefinedMethodCallResult.html
@@ -1,1 +1,9 @@
 <p>Undefined method call result</p>
+<h2>Explanation</h2>
+<pre>
+_block
+    _local var << example_exemplar.undefined_method_call_result_example()
+_endblock
+$
+</pre>
+<p>The example shows a call to a method for which the return types in the type-doc has not been defined. Add type-doc with the appropriate <pre>@return</pre>s to the method, or the type database.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/UndefinedMethodCallResult.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/UndefinedMethodCallResult.html
@@ -1,0 +1,1 @@
+<p>Undefined method call result</p>


### PR DESCRIPTION
For an example how the Wiki will look after this PR: 
- https://github.com/sebastiaanspeck/magik-tools/wiki/Checks-Index
- https://github.com/sebastiaanspeck/magik-tools/wiki/Check-EmptyBlock

```diff
+# `empty-block` - Block is empty and can be removed
-Block is empty and can be removed.

## Non-compliant Code Example
-    
-    
    _if a
    _then
      write(a)
    _else
      # block without any contents
    _endif
    

## Compliant Code Example
-    
-    
    _if a
    _then
      write(a)
    _endif
```
