### PR TITLE
Only auto-fix Magik files when using `magik-lint --apply-fixes`

### DIFF
--- a/changes/387.bugfix.md
+++ b/changes/387.bugfix.md
@@ -1,0 +1,1 @@
+Only auto-fix Magik files when using `magik-lint --apply-fixes`.

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magik/fixers/FormattingFixer.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magik/fixers/FormattingFixer.java
@@ -31,7 +31,8 @@ public class FormattingFixer extends CheckFixer {
     }
 
     if (!this.canFormat(magikFile)) {
-      LOGGER.warn("Cannot format due to syntax errors");
+      final String filePath = magikFile.getUri().getPath();
+      LOGGER.warn("Cannot format %s due to syntax errors".formatted(filePath));
       return Collections.emptyList();
     }
 

--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikFixer.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikFixer.java
@@ -45,6 +45,10 @@ public class MagikFixer {
    */
   public void run(final Collection<Path> paths) throws IOException {
     for (final Path path : paths) {
+      if (!path.endsWith(".magik")) {
+        continue;
+      }
+
       final MagikFile magikFile = this.buildMagikFile(path);
       if (this.isFileIgnored(magikFile)) {
         continue;


### PR DESCRIPTION
Fixes #385 