### PR TITLE
Format label of proc as `_proc @label() _endproc`

### DIFF
--- a/changes/409.feature.md
+++ b/changes/409.feature.md
@@ -1,4 +1,4 @@
 Format label of proc as `_proc @label() _endproc`.
 
-Previously, labels for procedures were formatted as `_proc@label() _endproc`. This change
-makes it consistent with other labels.
+Previously, labels for procedures were formatted as `_proc@label() _endproc`.
+This change makes it consistent with other labels.

--- a/changes/409.feature.md
+++ b/changes/409.feature.md
@@ -1,0 +1,4 @@
+Format label of proc as `_proc @label() _endproc`.
+
+Previously, labels for procedures were formatted as `_proc@label() _endproc`. This change
+makes it consistent with other labels.

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/formatting/SpecificsFormattingWalker.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/formatting/SpecificsFormattingWalker.java
@@ -70,14 +70,6 @@ class SpecificsFormattingWalker extends FormattingWalker {
   }
 
   @Override
-  protected void walkPostProcedureDefinition(final AstNode node) {
-    final AstNode procedureNameNode = node.getFirstChild(MagikGrammar.PROCEDURE_NAME);
-    if (procedureNameNode != null) {
-      this.ensureNoWhitespaceBeforeIfNotFirstTextOnLine(procedureNameNode);
-    }
-  }
-
-  @Override
   protected void walkPostMethodInvocation(final AstNode node) {
     // Ensure no whitespace before the `.` or `[` token.
     final List<AstNode> childNodes = node.getChildren();

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/formatting/FormattingWalkerTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/formatting/FormattingWalkerTest.java
@@ -198,7 +198,7 @@ class FormattingWalkerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "_proc@b(x, y, z) _endproc",
+        "_proc @b(x, y, z) _endproc",
         "_proc(x, y, z) _endproc",
       })
   void testProcDefinitionParameters(final String code) {


### PR DESCRIPTION
Format label of proc as `_proc @label() _endproc`, making it consistent with other labels.

Fixes #386.
Keep @sebastiaanspeck happy.