### PR TITLE
Fix diagnostics resource

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,14 @@
     },
     {
       "type": "java",
+      "name": "Debug (Attach)-MagikSessionWrapper<magik-session-wrapper>",
+      "request": "attach",
+      "hostName": "localhost",
+      "port": 5008,
+      "projectName": "magik-session-wrapper"
+    },
+    {
+      "type": "java",
       "name": "Debug (Launch)-MagikToolkit<sslr-magik-toolkit>",
       "request": "launch",
       "mainClass": "nl.ramsolutions.sw.magik.toolkit.MagikToolkit",

--- a/changes/410.bugfix.md
+++ b/changes/410.bugfix.md
@@ -1,0 +1,13 @@
+Fix diagnostics source.
+
+Changes the source, in VSCode, from:
+
+```text
+mlint (undefined-method-call-result)(undefined-method-call-result)
+```
+
+To:
+
+```text
+mlint (undefined-method-call-result)
+```

--- a/magik-language-server/client-vscode/client/src/alias-task-provider.ts
+++ b/magik-language-server/client-vscode/client/src/alias-task-provider.ts
@@ -151,8 +151,9 @@ function getCommandLine(runAliasPath: fs.PathLike, aliasesPath: fs.PathLike, ent
 			throw new Error(errorMessage);
 		}
 
+		const javaDebuggerOptions = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=127.0.0.1:5008';
 		const jar = path.join(__dirname, '..', '..', 'server', 'magik-session-wrapper-' + MAGIK_TOOLS_VERSION + '.jar');
-		commandLine = `${javaExec} -jar ${jar} --debug -- ${commandLine}`;
+		commandLine = `${javaExec} ${javaDebuggerOptions} -jar ${jar} --debug -- ${commandLine}`;
 	}
 
 	return commandLine;

--- a/magik-language-server/client-vscode/client/src/debug-provider.ts
+++ b/magik-language-server/client-vscode/client/src/debug-provider.ts
@@ -33,7 +33,7 @@ class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFact
 			return;
 		}
 		const jar = path.join(__dirname, '..', '..', 'server', 'magik-debug-adapter-' + MAGIK_TOOLS_VERSION + '.jar');
-		const javaDebuggerOptions = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=5006';
+		const javaDebuggerOptions = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=127.0.0.1:5006';
 
 		const command = javaExec.toString();
 		const args = [javaDebuggerOptions, '-jar', jar, '--debug'];

--- a/magik-language-server/client-vscode/client/src/language-client.ts
+++ b/magik-language-server/client-vscode/client/src/language-client.ts
@@ -44,7 +44,7 @@ export class MagikLanguageClient implements vscode.Disposable {
 		}
 
 		const jar = path.join(__dirname, '..', '..', 'server', 'magik-language-server-' + MAGIK_TOOLS_VERSION + '.jar');
-		const javaDebuggerOptions = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=5005';
+		const javaDebuggerOptions = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=y,address=127.0.0.1:5005';
 
 		const serverOptions: vscodeLanguageClient.ServerOptions = {
 			run: {

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/diagnostics/ChecksDiagnosticsProvider.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/diagnostics/ChecksDiagnosticsProvider.java
@@ -71,7 +71,7 @@ public class ChecksDiagnosticsProvider {
               final String message = issue.message();
               final DiagnosticSeverity severity = this.getCheckSeverity(holder);
               final String checkKeyKebabCase = holder.getCheckKeyKebabCase();
-              final String diagnosticSource = "mlint (%s)".formatted(checkKeyKebabCase);
+              final String diagnosticSource = "mlint";
               return new Diagnostic(range, message, severity, diagnosticSource, checkKeyKebabCase);
             })
         .toList();

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/SimpleVectorNodeHelper.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/helpers/SimpleVectorNodeHelper.java
@@ -58,6 +58,10 @@ public class SimpleVectorNodeHelper {
     }
     final AstNode expressionNode = expressionNodes.get(nth);
     final AstNode atomNode = expressionNode.getFirstChild(MagikGrammar.ATOM);
+    if (atomNode == null) {
+      return null;
+    }
+
     return atomNode.getFirstChild(type);
   }
 }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/parser/TypeDocParser.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/parser/TypeDocParser.java
@@ -269,7 +269,11 @@ public class TypeDocParser {
     final AstNode node = this.getTypeDocNode();
     return node.getChildren(TypeDocGrammar.SLOT).stream()
         .filter(this::noEmptyName)
-        .collect(Collectors.toMap(this::getName, this::getTypeString));
+        .collect(
+            Collectors.toMap(
+                this::getName,
+                this::getTypeString,
+                (a, b) -> a)); // In case of duplicate param names, keep the first one.
   }
 
   /**


### PR DESCRIPTION
Fix diagnostics source. Changes the source, in VSCode, from:
```
mlint (undefined-method-call-result)(undefined-method-call-result)
``` 

To:
```
mlint (undefined-method-call-result)
``` 
