### PR TITLE
Fix parsing loose `end` in product.def and module.def

### DIFF
--- a/changes/416.bugfix.md
+++ b/changes/416.bugfix.md
@@ -1,0 +1,1 @@
+Fix parsing loose end in `product.def` and `module.def`.

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/moduledef/api/ModuleDefinitionGrammar.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/moduledef/api/ModuleDefinitionGrammar.java
@@ -58,6 +58,7 @@ public enum ModuleDefinitionGrammar implements GrammarRuleKey {
 
   SYNTAX_ERROR_SECTION,
   SYNTAX_ERROR_LINE,
+  SYNTAX_ERROR_END,
   SYNTAX_ERROR,
 
   IDENTIFIERS,
@@ -102,7 +103,8 @@ public enum ModuleDefinitionGrammar implements GrammarRuleKey {
                     SYSTEM_INSTALLATION,
                     SPACING,
                     SYNTAX_ERROR_SECTION,
-                    SYNTAX_ERROR_LINE)),
+                    SYNTAX_ERROR_LINE,
+                    SYNTAX_ERROR_END)),
             builder.token(GenericTokenType.EOF, builder.endOfInput()));
 
     builder
@@ -115,6 +117,7 @@ public enum ModuleDefinitionGrammar implements GrammarRuleKey {
         .is(
             builder.regexp("(?!" + ModuleDefinitionKeyword.END.getValue() + ").+"),
             builder.optional(builder.regexp("[\r\n]+")));
+    builder.rule(SYNTAX_ERROR_END).is(ModuleDefinitionKeyword.END);
 
     builder.rule(MODULE_IDENTIFICATION).is(MODULE_NAME, WHITESPACE, VERSION);
     builder.rule(MODULE_NAME).is(IDENTIFIER);

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/moduledef/parser/ModuleDefParser.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/moduledef/parser/ModuleDefParser.java
@@ -30,6 +30,8 @@ public class ModuleDefParser {
         ModuleDefinitionGrammar.SYNTAX_ERROR_SECTION, ModuleDefinitionGrammar.SYNTAX_ERROR);
     RULE_MAPPING.put(
         ModuleDefinitionGrammar.SYNTAX_ERROR_LINE, ModuleDefinitionGrammar.SYNTAX_ERROR);
+    RULE_MAPPING.put(
+        ModuleDefinitionGrammar.SYNTAX_ERROR_END, ModuleDefinitionGrammar.SYNTAX_ERROR);
   }
 
   /** Constructor with default charset. */

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammar.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammar.java
@@ -30,6 +30,7 @@ public enum ProductDefinitionGrammar implements GrammarRuleKey {
 
   SYNTAX_ERROR_SECTION,
   SYNTAX_ERROR_LINE,
+  SYNTAX_ERROR_END,
   SYNTAX_ERROR,
 
   SPACING,
@@ -65,7 +66,8 @@ public enum ProductDefinitionGrammar implements GrammarRuleKey {
                     VERSION,
                     SPACING,
                     SYNTAX_ERROR_SECTION,
-                    SYNTAX_ERROR_LINE)),
+                    SYNTAX_ERROR_LINE,
+                    SYNTAX_ERROR_END)),
             builder.token(GenericTokenType.EOF, builder.endOfInput()));
 
     builder
@@ -79,6 +81,7 @@ public enum ProductDefinitionGrammar implements GrammarRuleKey {
         .is(
             builder.regexp("(?!" + ProductDefinitionKeyword.END.getValue() + ").+"),
             builder.optional(builder.regexp("[\r\n]+")));
+    builder.rule(SYNTAX_ERROR_END).is(ProductDefinitionKeyword.END);
 
     builder.rule(PRODUCT_IDENTIFICATION).is(PRODUCT_NAME, WHITESPACE, PRODUCT_TYPE);
     builder.rule(PRODUCT_NAME).is(IDENTIFIER);

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/parser/ProductDefParser.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/parser/ProductDefParser.java
@@ -30,6 +30,8 @@ public class ProductDefParser {
         ProductDefinitionGrammar.SYNTAX_ERROR_SECTION, ProductDefinitionGrammar.SYNTAX_ERROR);
     RULE_MAPPING.put(
         ProductDefinitionGrammar.SYNTAX_ERROR_LINE, ProductDefinitionGrammar.SYNTAX_ERROR);
+    RULE_MAPPING.put(
+        ProductDefinitionGrammar.SYNTAX_ERROR_END, ProductDefinitionGrammar.SYNTAX_ERROR);
   }
 
   /** Constructor with default charset. */

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/ModuleDefinitionGrammarTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/ModuleDefinitionGrammarTest.java
@@ -6,7 +6,7 @@ import com.sonar.sslr.api.Grammar;
 import nl.ramsolutions.sw.moduledef.api.ModuleDefinitionGrammar;
 import org.junit.jupiter.api.Test;
 
-/** Tests for SwModuleDefinitionGrammar. */
+/** Tests for {@link ModuleDefinitionGrammar}. */
 class ModuleDefinitionGrammarTest {
   private final Grammar grammar = ModuleDefinitionGrammar.create();
 
@@ -208,18 +208,18 @@ class ModuleDefinitionGrammarTest {
         .matches("module 1")
         .matches(
             """
-        test_module_a 1
-        requires
-          test_module_b
-        end
-        """)
+            test_module_a 1
+            requires
+              test_module_b
+            end
+            """)
         .matches(
             """
-          test_module_a 1
-          reqs
-            test_module_b
-          end
-          """) // Syntax error.
+            test_module_a 1
+            reqs
+              test_module_b
+            end
+            """) // Syntax error.
         .matches(
             """
             test_module_a 1
@@ -228,6 +228,15 @@ class ModuleDefinitionGrammarTest {
             """
             test_module_a 1
             some extra line
+            """) // Syntax error.
+        .matches(
+            """
+            test_module_a 1
+            requires
+              test_module_b
+            end
+
+            end
             """); // Syntax error.
   }
 }

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/ProductDefinitionGrammarTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/api/ProductDefinitionGrammarTest.java
@@ -6,7 +6,7 @@ import com.sonar.sslr.api.Grammar;
 import nl.ramsolutions.sw.productdef.api.ProductDefinitionGrammar;
 import org.junit.jupiter.api.Test;
 
-/** Tests for SwProductDefinitionGrammar. */
+/** Tests for {@link ProductDefinitionGrammar}. */
 class ProductDefinitionGrammarTest {
   private final Grammar grammar = ProductDefinitionGrammar.create();
 
@@ -105,22 +105,31 @@ class ProductDefinitionGrammarTest {
             requires
               test_product_b
             end
-        """)
+            """)
         .matches(
             """
-          test_product_a layered_product
-          reqs
-            test_product_b
-          end
-        """) // Syntax error.
+            test_product_a layered_product
+            reqs
+              test_product_b
+            end
+            """) // Syntax error.
         .matches(
             """
             test_product_a layered_product
             some extra line""") // Syntax error.
         .matches(
             """
-              test_product_a layered_product
+            test_product_a layered_product
             some extra line
+            """) // Syntax error.
+        .matches(
+            """
+            test_product_a layered_product
+            requires
+              test_product_b
+            end
+
+            end
             """); // Syntax error.
   }
 }


### PR DESCRIPTION
Fix parsing loose `end` in product.def and module.def.

Fixes #415.