### PR TITLE
Fix parsing of version numbers in `ProductDefinitionGrammar`

### DIFF
--- a/changes/438.bugfix.md
+++ b/changes/438.bugfix.md
@@ -1,0 +1,1 @@
+Fix parsing of version numbers in `ProductDefinitionGrammar`, such as `1.1.0.1-1 Beta`.

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammar.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammar.java
@@ -114,7 +114,9 @@ public enum ProductDefinitionGrammar implements GrammarRuleKey {
                 ProductDefinitionKeyword.CONFIG_PRODUCT));
     builder.rule(PRODUCT_REFS).is(builder.zeroOrMore(PRODUCT_REF, SPACING));
     builder.rule(PRODUCT_REF).is(PRODUCT_NAME, builder.optional(WHITESPACE, VERSION));
-    builder.rule(VERSION_NUMBER).is(NUMBER, builder.zeroOrMore(".", NUMBER));
+    builder
+        .rule(VERSION_NUMBER)
+        .is(NUMBER, builder.zeroOrMore(".", NUMBER), builder.optional("-", NUMBER));
     builder.rule(FREE_LINES).is(builder.zeroOrMore(FREE_LINE));
     builder
         .rule(FREE_LINE)

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammarTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/productdef/api/ProductDefinitionGrammarTest.java
@@ -77,7 +77,9 @@ class ProductDefinitionGrammarTest {
         .matches("version 1.0")
         .matches("version 1.0.1")
         .matches("version 1.0.1 RC1")
-        .matches("version 1.0 RC1");
+        .matches("version 1.0 RC1")
+        .matches("version 1.1.0.1-1 Beta")
+        .matches("version 1.2.3.4-5");
   }
 
   @Test


### PR DESCRIPTION
Fix parsing of version numbers in `ProductDefinitionGrammar`, such as `1.1.0.1-1 Beta`.

Fixes #435.