### PR TITLE
Rename type doc parameters.

### DIFF
--- a/changes/441.bugfix.md
+++ b/changes/441.bugfix.md
@@ -1,0 +1,13 @@
+Rename parameter names in type doc.
+
+In the following example, when the parameter `param1` is ranamed, the
+type doc is now also updated.
+
+```magik
+_method a.b(param1, param2)
+    ## Example method.
+    ## @param {sw:integer} param1 First parameter
+    ## @param {sw:rope} param2 Second parameter
+    write(param1, param2)
+_endmethod
+```

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/rename/VariableRenamer.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/rename/VariableRenamer.java
@@ -3,7 +3,9 @@ package nl.ramsolutions.sw.magik.languageserver.rename;
 import com.sonar.sslr.api.AstNode;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -15,6 +17,7 @@ import nl.ramsolutions.sw.magik.analysis.scope.Scope;
 import nl.ramsolutions.sw.magik.analysis.scope.ScopeEntry;
 import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import nl.ramsolutions.sw.magik.languageserver.Lsp4jConversion;
+import nl.ramsolutions.sw.magik.parser.TypeDocParser;
 import org.eclipse.lsp4j.PrepareRenameResult;
 
 /** Magik variable renamer. */
@@ -62,16 +65,31 @@ class VariableRenamer extends Renamer {
     // Provide edits.
     final URI uri = magikFile.getUri();
     final AstNode definitionNode = scopeEntry.getDefinitionNode();
-    final List<TextEdit> textEdits =
-        Stream.concat(Stream.of(definitionNode), scopeEntry.getUsages().stream())
-            .map(
-                renameNode ->
-                    renameNode.isNot(MagikGrammar.IDENTIFIER)
-                        ? renameNode.getFirstChild(MagikGrammar.IDENTIFIER)
-                        : renameNode)
-            .map(Range::new)
-            .map(range -> new TextEdit(range, newName))
-            .toList();
+    final List<TextEdit> textEdits = new ArrayList<>();
+
+    // Add variable usage edits.
+    Stream.concat(Stream.of(definitionNode), scopeEntry.getUsages().stream())
+        .map(
+            renameNode ->
+                renameNode.isNot(MagikGrammar.IDENTIFIER)
+                    ? renameNode.getFirstChild(MagikGrammar.IDENTIFIER)
+                    : renameNode)
+        .map(Range::new)
+        .map(range -> new TextEdit(range, newName))
+        .forEach(textEdits::add);
+
+    // Also rename in type doc.
+    if (scopeEntry.isType(ScopeEntry.Type.PARAMETER)) {
+      final String oldName = definitionNode.getTokenOriginalValue();
+      final List<TextEdit> typeDocEdits = this.getTypeDocEdits(definitionNode, oldName, newName);
+      textEdits.addAll(typeDocEdits);
+    }
+
+    // Sort edits by position (line, then column).
+    textEdits.sort(
+        Comparator.comparingInt((TextEdit edit) -> edit.getRange().getStartPosition().getLine())
+            .thenComparingInt(edit -> edit.getRange().getStartPosition().getColumn()));
+
     return Map.of(uri, textEdits);
   }
 
@@ -97,5 +115,36 @@ class VariableRenamer extends Renamer {
     }
 
     return scope.getScopeEntry(node);
+  }
+
+  /**
+   * Get text edits for renaming parameter in type doc.
+   *
+   * @param definitionNode The parameter definition node.
+   * @param oldName The old parameter name.
+   * @param newName The new parameter name.
+   * @return List of text edits for type doc parameter names.
+   */
+  private List<TextEdit> getTypeDocEdits(
+      final AstNode definitionNode, final String oldName, final String newName) {
+    // Find the parent method/procedure definition node.
+    final AstNode methodNode =
+        definitionNode.getFirstAncestor(
+            MagikGrammar.METHOD_DEFINITION, MagikGrammar.PROCEDURE_DEFINITION);
+    if (methodNode == null) {
+      return Collections.emptyList();
+    }
+
+    // Parse the type doc for the method/procedure.
+    final TypeDocParser typeDocParser = new TypeDocParser(methodNode);
+    final Map<AstNode, String> parameterNameNodes = typeDocParser.getParameterNameNodes();
+
+    // Find parameter name nodes matching the old name and create text edits.
+    return parameterNameNodes.entrySet().stream()
+        .filter(entry -> entry.getValue().equals(oldName))
+        .map(Map.Entry::getKey)
+        .map(Range::new)
+        .map(range -> new TextEdit(range, newName))
+        .toList();
   }
 }

--- a/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/rename/VariableRenamerTest.java
+++ b/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/rename/VariableRenamerTest.java
@@ -161,4 +161,30 @@ public class VariableRenamerTest {
                     new TextEdit(new Range(new Position(1, 22), new Position(1, 28)), "new"),
                     new TextEdit(new Range(new Position(2, 10), new Position(2, 16)), "new"))));
   }
+
+  @Test
+  void testRenameParameterInTypeDoc() throws IOException {
+    final String code =
+        """
+        _method a.b(param1, param2)
+            ## Example method.
+            ## @param {sw:integer} param1 First parameter
+            ## @param {sw:rope} param2 Second parameter
+            write(param1, param2)
+        _endmethod
+        """;
+    final Position position = new Position(5, 12); // On `param1` in write call.
+
+    final VariableRenamer renamer = this.getRenamer(code, position);
+    final Map<URI, List<TextEdit>> renames = renamer.provideRename("newParam");
+    assertThat(renames)
+        .isEqualTo(
+            Map.of(
+                URI.create("memory:///source.magik"),
+                List.of(
+                    new TextEdit(new Range(new Position(1, 12), new Position(1, 18)), "newParam"),
+                    new TextEdit(new Range(new Position(3, 27), new Position(3, 33)), "newParam"),
+                    new TextEdit(
+                        new Range(new Position(5, 10), new Position(5, 16)), "newParam"))));
+  }
 }


### PR DESCRIPTION
Rename parameter names in type doc.

In the following example, when the parameter `param1` is ranamed, the
type doc is now also updated.

```magik
_method a.b(param1, param2)
    ## Example method.
    ## @param {sw:integer} param1 First parameter
    ## @param {sw:rope} param2 Second parameter
    write(param1, param2)
_endmethod
```
