### PR TITLE
Add check SystemCommandUseSimpleVector

### DIFF
--- a/changes/458.feature.md
+++ b/changes/458.feature.md
@@ -1,3 +1,4 @@
 Add check SystemCommandUseSimpleVector.
 
-This checks enforces that a simple_vector is used for sw:system.do_command() and friends.
+This checks enforces that a `simple_vector` is used for
+`sw:system.do_command()` and friends.

--- a/changes/458.feature.md
+++ b/changes/458.feature.md
@@ -1,0 +1,3 @@
+Add check SystemCommandUseSimpleVector.
+
+This checks enforces that a simple_vector is used for sw:system.do_command() and friends.

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/checks/MagikTypedCheckList.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/checks/MagikTypedCheckList.java
@@ -17,6 +17,7 @@ import nl.ramsolutions.sw.checks.magiktyped.MethodReturnTypesMatchDocTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.ModuleRequiredForGlobalTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.SlotExistsTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.SwChar16VectorEvaluateInvocationTypedCheck;
+import nl.ramsolutions.sw.checks.magiktyped.SystemCommandUseSimpleVectorTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.TypeDocTypeExistsTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.UndefinedMethodCallResultTypedCheck;
 import nl.ramsolutions.sw.checks.magiktyped.fixers.TypeDocParameterFixer;
@@ -56,6 +57,7 @@ public final class MagikTypedCheckList extends CheckList<MagikCheck, MagikTypedC
         ModuleRequiredForGlobalTypedCheck.class,
         SlotExistsTypedCheck.class,
         SwChar16VectorEvaluateInvocationTypedCheck.class,
+        SystemCommandUseSimpleVectorTypedCheck.class,
         TypeDocTypeExistsTypedCheck.class,
         UndefinedMethodCallResultTypedCheck.class);
   }

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped/SystemCommandUseSimpleVectorTypedCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped/SystemCommandUseSimpleVectorTypedCheck.java
@@ -1,0 +1,59 @@
+package nl.ramsolutions.sw.checks.magiktyped;
+
+import com.sonar.sslr.api.AstNode;
+import java.util.List;
+import nl.ramsolutions.sw.checks.MagikTypedCheck;
+import nl.ramsolutions.sw.magik.analysis.helpers.MethodInvocationNodeHelper;
+import nl.ramsolutions.sw.magik.analysis.typing.ExpressionResultString;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+import nl.ramsolutions.sw.magik.analysis.typing.reasoner.LocalTypeReasonerState;
+import org.sonar.check.Rule;
+
+/** Test if referenced type is known. */
+@Rule(key = SystemCommandUseSimpleVectorTypedCheck.CHECK_KEY)
+public class SystemCommandUseSimpleVectorTypedCheck extends MagikTypedCheck {
+
+  @SuppressWarnings("checkstyle:JavadocVariable")
+  public static final String CHECK_KEY = "SystemCommandUseSimpleVector";
+
+  private static final String MESSAGE = "Use a simple_vector instead of a (concatenated) string";
+
+  private static final List<String> TARGET_METHODS =
+      List.of(
+          "do_command()",
+          "input_from_command()",
+          "output_to_command()",
+          "start_command()",
+          "start_command_with_io()");
+  private static final TypeString SW_SYSTEM = TypeString.ofIdentifier("system", "sw");
+
+  @Override
+  protected void walkPreMethodInvocation(final AstNode node) {
+    final TypeString receiverTypeStr = this.getTypeInvokedOn(node).getWithoutGenerics();
+    if (!receiverTypeStr.equals(SystemCommandUseSimpleVectorTypedCheck.SW_SYSTEM)) {
+      return;
+    }
+
+    final MethodInvocationNodeHelper helper = new MethodInvocationNodeHelper(node);
+    final String methodName = helper.getMethodName();
+    if (!SystemCommandUseSimpleVectorTypedCheck.TARGET_METHODS.contains(methodName)) {
+      return;
+    }
+
+    // Get first argument type.
+    final List<AstNode> argumentExpressionNodes = helper.getArgumentExpressionNodes();
+    if (argumentExpressionNodes.isEmpty()) {
+      return;
+    }
+
+    final LocalTypeReasonerState state = this.getTypeReasonerState();
+    final AstNode argumentExpressionNode = argumentExpressionNodes.get(0);
+    final ExpressionResultString result = state.getNodeType(argumentExpressionNode);
+    final TypeString typeStr = result.get(0, TypeString.UNDEFINED);
+    if (typeStr.getWithoutGenerics().equals(TypeString.SW_SIMPLE_VECTOR)) {
+      return;
+    }
+
+    this.addIssue(node, SystemCommandUseSimpleVectorTypedCheck.MESSAGE);
+  }
+}

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SystemCommandUseSimpleVector.html
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SystemCommandUseSimpleVector.html
@@ -1,0 +1,17 @@
+<p>Use simple_vector for sw:system.do_command() and friends</p>
+<h2>Explanation</h2>
+<p>When using <code>sw:system.do_command()</code>, <code>sw:system.start_command()</code>, <code>sw:system.start_command_with_io()</code> or similar functions to execute system commands, it is recommended to use a <code>simple_vector</code> to pass the command. This helps to avoid command injection vulnerabilities, as the command and its arguments are clearly separated.</p>
+<p>An example where malicious user input leads to command injection:</p>
+<pre>
+_local user_input << "file.txt /etc/passwd" # Something a mailcious user entered.
+_local command << write_string("/bin/cat ", user_input)
+system.do_command(command)
+</pre>
+<p>In this example, the user input contains multiple space-separated values that will be interpreted as separate command arguments. When the command string <code>"/bin/cat file.txt /etc/passwd"</code> is executed, it will read both <code>file.txt</code> and <code>/etc/passwd</code>, allowing the malicious user to access sensitive system files.</p>
+<p>To mitigate this risk, use a <code>simple_vector</code> to pass the command and its arguments separately:</p>
+<pre>
+_local user_input << "file.txt /etc/passwd" # Something a mailcious user entered.
+_local command << {"/bin/cat", user_input}
+system.do_command(command)
+</pre>
+<p>In this corrected example, the entire user input is treated as a single argument to the command. The system will attempt to open a file literally named <code>"file.txt /etc/passwd"</code> (including the space), which prevents the injection attack. By using a <code>simple_vector</code>, each element is passed as a distinct, separate argument that cannot be further split or interpreted.</p>

--- a/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SystemCommandUseSimpleVector.json
+++ b/magik-checks/src/main/resources/nl/ramsolutions/sw/sonar/l10n/magiktyped/rules/SystemCommandUseSimpleVector.json
@@ -1,0 +1,16 @@
+{
+  "title": "Use simple_vector for sw:system.do_command() and friends",
+  "type": "VULNERABILITY",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "15min"
+  },
+  "tags": [
+    "typing",
+    "vulnerability"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "SystemCommandUseSimpleVector",
+  "sqKey": "system-command-use-simple-vector"
+}

--- a/magik-checks/src/test/java/nl/ramsolutions/sw/checks/magiktyped/SystemCommandUseSimpleVectorTypedCheckTest.java
+++ b/magik-checks/src/test/java/nl/ramsolutions/sw/checks/magiktyped/SystemCommandUseSimpleVectorTypedCheckTest.java
@@ -1,0 +1,65 @@
+package nl.ramsolutions.sw.checks.magiktyped;
+
+import static nl.ramsolutions.sw.checks.magiktyped.MagikTypedCheckAssert.assertThat;
+
+import java.util.Collections;
+import nl.ramsolutions.sw.checks.MagikTypedCheck;
+import nl.ramsolutions.sw.magik.analysis.definitions.DefinitionKeeper;
+import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
+import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
+import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Tests for {@link SystemCommandUseSimpleVectorTypedCheck}. */
+class SystemCommandUseSimpleVectorTypedCheckTest {
+
+  private static final ExemplarDefinition SYSTEM_EXEMPLAR_DEFINITION =
+      new ExemplarDefinition(
+          null,
+          null,
+          null,
+          null,
+          null,
+          ExemplarDefinition.Sort.SLOTTED,
+          TypeString.ofIdentifier("system", "sw"),
+          Collections.emptyList(),
+          Collections.emptyList(),
+          null);
+
+  private IDefinitionKeeper getDefinitionKeeper() {
+    final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
+    definitionKeeper.add(SYSTEM_EXEMPLAR_DEFINITION);
+    return definitionKeeper;
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "system.do_command('ls -la')",
+        "system.input_from_command('grep pattern')",
+        "system.output_to_command('echo Hello World')",
+        "system.start_command('date')",
+        "system.start_command_with_io('whoami')"
+      })
+  void testInvalid(final String code) {
+    final IDefinitionKeeper definitionKeeper = this.getDefinitionKeeper();
+    final MagikTypedCheck check = new SystemCommandUseSimpleVectorTypedCheck();
+    assertThat(check).reportsIssueCount(code, definitionKeeper, 1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "system.do_command({'ls', '-la'})",
+        "system.input_from_command({'grep', 'pattern'})",
+        "system.output_to_command({'echo', 'Hello World'})",
+        "system.start_command({'date'})",
+        "system.start_command_with_io({'whoami'})"
+      })
+  void testValid(final String code) {
+    final IDefinitionKeeper definitionKeeper = this.getDefinitionKeeper();
+    final MagikTypedCheck check = new SystemCommandUseSimpleVectorTypedCheck();
+    assertThat(check).reportsNoIssues(code, definitionKeeper);
+  }
+}


### PR DESCRIPTION
Add check `SystemCommandUseSimpleVector`.

This checks enforces that a `simple_vector` is used for `sw:system.do_command()` and friends.
