### PR TITLE
Report `AbstractMethodNotImplemented` on exemplar/mixin definition, instead of on method definition

### DIFF
--- a/changes/589.bugfix.md
+++ b/changes/589.bugfix.md
@@ -1,0 +1,6 @@
+Report `AbstractMethodNotImplemented` on exemplar/mixin definition, instead of on method definition.
+
+The check now flags the exemplar or mixin definition that fails to implement an inherited
+abstract method, instead of an unrelated method definition. It is driven by the
+exemplar/mixin definitions in the file, so an exemplar is also reported when it defines no
+methods of its own.

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped/AbstractMethodNotImplementedTypedCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/checks/magiktyped/AbstractMethodNotImplementedTypedCheck.java
@@ -2,17 +2,18 @@ package nl.ramsolutions.sw.checks.magiktyped;
 
 import com.sonar.sslr.api.AstNode;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import nl.ramsolutions.sw.checks.MagikTypedCheck;
 import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
 import nl.ramsolutions.sw.magik.analysis.definitions.MethodDefinition;
-import nl.ramsolutions.sw.magik.analysis.helpers.MethodDefinitionNodeHelper;
+import nl.ramsolutions.sw.magik.analysis.helpers.ArgumentsNodeHelper;
 import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
 import nl.ramsolutions.sw.magik.analysis.typing.TypeStringResolver;
+import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import org.sonar.check.Rule;
 
-/** Check if concrete exemplars implement all inherited abstract methods. */
+/** Check if exemplars/mixins implement all inherited abstract methods. */
 @Rule(key = AbstractMethodNotImplementedTypedCheck.CHECK_KEY)
 public class AbstractMethodNotImplementedTypedCheck extends MagikTypedCheck {
 
@@ -21,52 +22,61 @@ public class AbstractMethodNotImplementedTypedCheck extends MagikTypedCheck {
 
   private static final String MESSAGE = "Abstract method %s.%s is not implemented by %s.";
 
-  private final Set<TypeString> checkedTypes = new HashSet<>();
-
   @Override
-  protected void walkPostMethodDefinition(final AstNode node) {
-    final MethodDefinitionNodeHelper helper = new MethodDefinitionNodeHelper(node);
-    final TypeString typeStr = helper.getTypeString();
-
-    // Only check each exemplar once per file.
-    if (this.checkedTypes.contains(typeStr)) {
-      return;
-    }
-    this.checkedTypes.add(typeStr);
-
+  protected void walkPostMagik(final AstNode node) {
     final TypeStringResolver resolver = this.getTypeStringResolver();
-    final ExemplarDefinition exemplarDef = resolver.getExemplarDefinition(typeStr);
-    if (exemplarDef == null) {
-      return;
-    }
+    this.getMagikFile().getMagikDefinitions().stream()
+        .filter(ExemplarDefinition.class::isInstance)
+        .map(ExemplarDefinition.class::cast)
+        .forEach(exemplarDefinition -> this.checkExemplarDefinition(resolver, exemplarDefinition));
+  }
 
-    // Collect all abstract methods from ancestors.
-    final Collection<TypeString> ancestors = resolver.getAllAncestors(typeStr);
-    for (final TypeString ancestorTypeStr : ancestors) {
-      final Collection<MethodDefinition> ancestorMethods =
-          resolver.getRespondingMethodDefinitions(ancestorTypeStr);
-      for (final MethodDefinition ancestorMethod : ancestorMethods) {
-        if (!ancestorMethod.getModifiers().contains(MethodDefinition.Modifier.ABSTRACT)) {
-          continue;
-        }
+  private void checkExemplarDefinition(
+      final TypeStringResolver resolver, final ExemplarDefinition exemplarDefinition) {
+    final TypeString typeStr = exemplarDefinition.getTypeString();
 
-        final String methodName = ancestorMethod.getMethodName();
-
-        // Check if the current type has a concrete implementation.
-        final Collection<MethodDefinition> implementations =
-            resolver.getRespondingMethodDefinitions(typeStr, methodName);
-        final boolean hasConcreteImpl =
-            implementations.stream()
-                .anyMatch(
-                    methodDef ->
-                        !methodDef.getModifiers().contains(MethodDefinition.Modifier.ABSTRACT));
-        if (!hasConcreteImpl) {
-          final String ancestorName = ancestorTypeStr.getFullString();
-          final String typeName = typeStr.getFullString();
-          final String message = MESSAGE.formatted(ancestorName, methodName, typeName);
-          this.addIssue(node, message);
+    // Collect all abstract methods inherited from ancestors, keyed by name so the same method
+    // reachable via multiple ancestors is only reported once.
+    final Map<String, MethodDefinition> abstractMethods = new HashMap<>();
+    for (final TypeString ancestorTypeStr : resolver.getAllAncestors(typeStr)) {
+      for (final MethodDefinition ancestorMethod :
+          resolver.getRespondingMethodDefinitions(ancestorTypeStr)) {
+        if (ancestorMethod.getModifiers().contains(MethodDefinition.Modifier.ABSTRACT)) {
+          abstractMethods.putIfAbsent(ancestorMethod.getMethodName(), ancestorMethod);
         }
       }
     }
+
+    for (final MethodDefinition abstractMethod : abstractMethods.values()) {
+      final String methodName = abstractMethod.getMethodName();
+
+      // Check if the exemplar has a concrete implementation.
+      final Collection<MethodDefinition> implementations =
+          resolver.getRespondingMethodDefinitions(typeStr, methodName);
+      final boolean hasConcreteImpl =
+          implementations.stream()
+              .anyMatch(
+                  methodDef ->
+                      !methodDef.getModifiers().contains(MethodDefinition.Modifier.ABSTRACT));
+      if (!hasConcreteImpl) {
+        final String ancestorName = abstractMethod.getTypeName().getFullString();
+        final String typeName = typeStr.getFullString();
+        final String message = MESSAGE.formatted(ancestorName, methodName, typeName);
+        final AstNode issueNode = this.getIssueNode(exemplarDefinition);
+        this.addIssue(issueNode, message);
+      }
+    }
+  }
+
+  private AstNode getIssueNode(final ExemplarDefinition exemplarDefinition) {
+    final AstNode definitionNode = exemplarDefinition.getNode();
+    final AstNode argumentsNode = definitionNode.getFirstDescendant(MagikGrammar.ARGUMENTS);
+    if (argumentsNode == null) {
+      return definitionNode;
+    }
+
+    final ArgumentsNodeHelper helper = new ArgumentsNodeHelper(argumentsNode);
+    final AstNode argumentNode = helper.getArgument(0);
+    return argumentNode != null ? argumentNode : definitionNode;
   }
 }

--- a/magik-checks/src/test/java/nl/ramsolutions/sw/checks/magiktyped/AbstractMethodNotImplementedTypedCheckTest.java
+++ b/magik-checks/src/test/java/nl/ramsolutions/sw/checks/magiktyped/AbstractMethodNotImplementedTypedCheckTest.java
@@ -5,6 +5,7 @@ import static nl.ramsolutions.sw.checks.magiktyped.MagikTypedCheckAssert.assertT
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import nl.ramsolutions.sw.checks.MagikTypedCheck;
 import nl.ramsolutions.sw.magik.analysis.definitions.DefinitionKeeper;
 import nl.ramsolutions.sw.magik.analysis.definitions.ExemplarDefinition;
@@ -20,27 +21,21 @@ class AbstractMethodNotImplementedTypedCheckTest {
   private static final TypeString TYPE_PARENT = TypeString.ofIdentifier("parent", "sw");
   private static final TypeString TYPE_CHILD = TypeString.ofIdentifier("child", "sw");
 
-  @Test
-  void testAbstractMethodImplemented() {
-    final String code =
-        """
-        _method child.do_something()
-          _return 1
-        _endmethod
-        """;
-    final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
+  private void addExemplar(
+      final IDefinitionKeeper definitionKeeper,
+      final TypeString typeStr,
+      final ExemplarDefinition.Sort sort,
+      final List<TypeString> parents) {
     definitionKeeper.add(
         new ExemplarDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            ExemplarDefinition.Sort.SLOTTED,
-            TYPE_PARENT,
-            Collections.emptyList(),
-            Collections.emptyList(),
-            null));
+            null, null, null, null, null, sort, typeStr, Collections.emptyList(), parents, null));
+  }
+
+  private void addMethod(
+      final IDefinitionKeeper definitionKeeper,
+      final TypeString typeStr,
+      final String methodName,
+      final Set<MethodDefinition.Modifier> modifiers) {
     definitionKeeper.add(
         new MethodDefinition(
             null,
@@ -48,133 +43,78 @@ class AbstractMethodNotImplementedTypedCheckTest {
             null,
             null,
             null,
-            TYPE_PARENT,
-            "do_something()",
-            EnumSet.of(MethodDefinition.Modifier.ABSTRACT),
+            typeStr,
+            methodName,
+            modifiers,
             Collections.emptyList(),
             null,
             null,
             ExpressionResultString.EMPTY,
             ExpressionResultString.EMPTY));
-    definitionKeeper.add(
-        new ExemplarDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            ExemplarDefinition.Sort.SLOTTED,
-            TYPE_CHILD,
-            Collections.emptyList(),
-            List.of(TYPE_PARENT),
-            null));
-    definitionKeeper.add(
-        new MethodDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            TYPE_CHILD,
-            "do_something()",
-            EnumSet.noneOf(MethodDefinition.Modifier.class),
-            Collections.emptyList(),
-            null,
-            null,
-            new ExpressionResultString(TypeString.SW_INTEGER),
-            ExpressionResultString.EMPTY));
+  }
+
+  @Test
+  void testAbstractMethodImplemented() {
+    final String code = "def_slotted_exemplar(:child, {}, :parent)\n";
+    final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
+    this.addExemplar(
+        definitionKeeper, TYPE_PARENT, ExemplarDefinition.Sort.SLOTTED, Collections.emptyList());
+    this.addMethod(
+        definitionKeeper,
+        TYPE_PARENT,
+        "do_something()",
+        EnumSet.of(MethodDefinition.Modifier.ABSTRACT));
+    this.addExemplar(
+        definitionKeeper, TYPE_CHILD, ExemplarDefinition.Sort.SLOTTED, List.of(TYPE_PARENT));
+    this.addMethod(
+        definitionKeeper,
+        TYPE_CHILD,
+        "do_something()",
+        EnumSet.noneOf(MethodDefinition.Modifier.class));
     final MagikTypedCheck check = new AbstractMethodNotImplementedTypedCheck();
     assertThat(check).reportsNoIssues(code, definitionKeeper);
   }
 
   @Test
   void testAbstractMethodNotImplemented() {
-    final String code =
-        """
-        _method child.other_method()
-          _return 1
-        _endmethod
-        """;
+    final String code = "def_slotted_exemplar(:child, {}, :parent)\n";
     final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
-    definitionKeeper.add(
-        new ExemplarDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            ExemplarDefinition.Sort.SLOTTED,
-            TYPE_PARENT,
-            Collections.emptyList(),
-            Collections.emptyList(),
-            null));
-    definitionKeeper.add(
-        new MethodDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            TYPE_PARENT,
-            "do_something()",
-            EnumSet.of(MethodDefinition.Modifier.ABSTRACT),
-            Collections.emptyList(),
-            null,
-            null,
-            ExpressionResultString.EMPTY,
-            ExpressionResultString.EMPTY));
-    definitionKeeper.add(
-        new ExemplarDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            ExemplarDefinition.Sort.SLOTTED,
-            TYPE_CHILD,
-            Collections.emptyList(),
-            List.of(TYPE_PARENT),
-            null));
-    definitionKeeper.add(
-        new MethodDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            TYPE_CHILD,
-            "other_method()",
-            EnumSet.noneOf(MethodDefinition.Modifier.class),
-            Collections.emptyList(),
-            null,
-            null,
-            new ExpressionResultString(TypeString.SW_INTEGER),
-            ExpressionResultString.EMPTY));
+    this.addExemplar(
+        definitionKeeper, TYPE_PARENT, ExemplarDefinition.Sort.SLOTTED, Collections.emptyList());
+    this.addMethod(
+        definitionKeeper,
+        TYPE_PARENT,
+        "do_something()",
+        EnumSet.of(MethodDefinition.Modifier.ABSTRACT));
+    this.addExemplar(
+        definitionKeeper, TYPE_CHILD, ExemplarDefinition.Sort.SLOTTED, List.of(TYPE_PARENT));
+    final MagikTypedCheck check = new AbstractMethodNotImplementedTypedCheck();
+    assertThat(check).reportsIssueCount(code, definitionKeeper, 1);
+  }
+
+  @Test
+  void testMixinAbstractMethodNotImplemented() {
+    final String code = "def_mixin(:child, :parent)\n";
+    final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
+    this.addExemplar(
+        definitionKeeper, TYPE_PARENT, ExemplarDefinition.Sort.SLOTTED, Collections.emptyList());
+    this.addMethod(
+        definitionKeeper,
+        TYPE_PARENT,
+        "do_something()",
+        EnumSet.of(MethodDefinition.Modifier.ABSTRACT));
+    this.addExemplar(
+        definitionKeeper, TYPE_CHILD, ExemplarDefinition.Sort.MIXIN, List.of(TYPE_PARENT));
     final MagikTypedCheck check = new AbstractMethodNotImplementedTypedCheck();
     assertThat(check).reportsIssueCount(code, definitionKeeper, 1);
   }
 
   @Test
   void testNoParents() {
-    final String code =
-        """
-        _method child.do_something()
-          _return 1
-        _endmethod
-        """;
+    final String code = "def_slotted_exemplar(:child, {})\n";
     final IDefinitionKeeper definitionKeeper = new DefinitionKeeper();
-    definitionKeeper.add(
-        new ExemplarDefinition(
-            null,
-            null,
-            null,
-            null,
-            null,
-            ExemplarDefinition.Sort.SLOTTED,
-            TYPE_CHILD,
-            Collections.emptyList(),
-            Collections.emptyList(),
-            null));
+    this.addExemplar(
+        definitionKeeper, TYPE_CHILD, ExemplarDefinition.Sort.SLOTTED, Collections.emptyList());
     final MagikTypedCheck check = new AbstractMethodNotImplementedTypedCheck();
     assertThat(check).reportsNoIssues(code, definitionKeeper);
   }


### PR DESCRIPTION
Report `AbstractMethodNotImplemented` on exemplar/mixin definition, instead of on method definition